### PR TITLE
fix(council): enforce per-request budget and recover from missing diff base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Harness working files — regenerated each plan/council run.
+.harness/active_plan.md
+.harness/last_council.md

--- a/.harness/scripts/council.py
+++ b/.harness/scripts/council.py
@@ -89,6 +89,12 @@ def get_plan_text(args: argparse.Namespace) -> tuple[str, str]:
         base = args.base
         diff = ""
         base_used = base
+        missing_ref_markers = (
+            "unknown revision",
+            "bad revision",
+            "ambiguous argument",
+            "not a tree object",
+        )
         try:
             diff = subprocess.check_output(
                 ["git", "diff", f"{base}...HEAD"],
@@ -97,14 +103,18 @@ def get_plan_text(args: argparse.Namespace) -> tuple[str, str]:
                 stderr=subprocess.STDOUT,
             )
         except subprocess.CalledProcessError as e:
-            tail = (e.output or "").strip().splitlines()
-            reason = tail[-1] if tail else "unknown error"
-            print(
-                f"[council] base ref '{base}' unavailable ({reason}); "
-                f"falling back to working-tree diff (git diff HEAD).",
-                file=sys.stderr,
-            )
-            base_used = "HEAD (working tree, base missing)"
+            output = (e.output or "").strip()
+            if any(m in output.lower() for m in missing_ref_markers):
+                tail = output.splitlines()
+                reason = tail[-1] if tail else "unknown error"
+                print(
+                    f"[council] base ref '{base}' unavailable ({reason}); "
+                    f"falling back to working-tree diff (git diff HEAD).",
+                    file=sys.stderr,
+                )
+                base_used = "HEAD (working tree, base missing)"
+            else:
+                die(f"git diff {base}...HEAD failed:\n{output}")
         if not diff.strip():
             try:
                 diff = subprocess.check_output(
@@ -112,7 +122,8 @@ def get_plan_text(args: argparse.Namespace) -> tuple[str, str]:
                     cwd=REPO_ROOT,
                     text=True,
                 )
-                base_used = "HEAD (working tree)"
+                if base_used == base:
+                    base_used = "HEAD (working tree, empty vs base)"
             except subprocess.CalledProcessError as e:
                 die(f"git diff HEAD failed: {e}")
         if not diff.strip():

--- a/.harness/scripts/council.py
+++ b/.harness/scripts/council.py
@@ -21,6 +21,7 @@ import json
 import os
 import subprocess
 import sys
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -86,6 +87,8 @@ def get_plan_text(args: argparse.Namespace) -> tuple[str, str]:
 
     if args.diff:
         base = args.base
+        diff = ""
+        base_used = base
         try:
             diff = subprocess.check_output(
                 ["git", "diff", f"{base}...HEAD"],
@@ -94,7 +97,14 @@ def get_plan_text(args: argparse.Namespace) -> tuple[str, str]:
                 stderr=subprocess.STDOUT,
             )
         except subprocess.CalledProcessError as e:
-            die(f"git diff failed: {e.output}")
+            tail = (e.output or "").strip().splitlines()
+            reason = tail[-1] if tail else "unknown error"
+            print(
+                f"[council] base ref '{base}' unavailable ({reason}); "
+                f"falling back to working-tree diff (git diff HEAD).",
+                file=sys.stderr,
+            )
+            base_used = "HEAD (working tree, base missing)"
         if not diff.strip():
             try:
                 diff = subprocess.check_output(
@@ -102,11 +112,12 @@ def get_plan_text(args: argparse.Namespace) -> tuple[str, str]:
                     cwd=REPO_ROOT,
                     text=True,
                 )
+                base_used = "HEAD (working tree)"
             except subprocess.CalledProcessError as e:
                 die(f"git diff HEAD failed: {e}")
         if not diff.strip():
             die("No diff to review (neither vs base nor working tree).")
-        return f"DIFF vs {base}", diff
+        return f"DIFF vs {base_used}", diff
 
     die("Pass --plan <path> or --diff.")
 
@@ -123,9 +134,40 @@ def build_prompt(persona_body: str, source_label: str, source_text: str, extra: 
     )
 
 
-def call_gemini(client, model: str, prompt: str, retries: int = 2) -> str:
+class RequestBudget:
+    """Thread-safe counter that bounds total Gemini requests including retries."""
+
+    def __init__(self, cap: int) -> None:
+        self.cap = cap
+        self.used = 0
+        self._lock = threading.Lock()
+
+    def try_charge(self) -> bool:
+        with self._lock:
+            if self.used >= self.cap:
+                return False
+            self.used += 1
+            return True
+
+    def snapshot(self) -> tuple[int, int]:
+        with self._lock:
+            return self.used, self.cap
+
+
+def call_gemini(
+    client,
+    model: str,
+    prompt: str,
+    budget: "RequestBudget",
+    retries: int = 2,
+) -> str:
     last_err: Exception | None = None
     for attempt in range(retries + 1):
+        if not budget.try_charge():
+            return (
+                f"(skipped: global request budget of {budget.cap} exhausted "
+                f"before attempt {attempt + 1})"
+            )
         try:
             resp = client.generate_content(prompt)
             return (resp.text or "").strip() or "(empty response)"
@@ -212,9 +254,11 @@ def main() -> int:
     model_client = genai.GenerativeModel(args.model)
 
     checklist = load_security_checklist()
+    budget = RequestBudget(CALL_CAP)
 
     print(f"[council] Model: {args.model}")
     print(f"[council] Source: {source_label}")
+    print(f"[council] Request budget: {CALL_CAP} (includes retries)")
     print(f"[council] Dispatching {len(personas)} angle reviews in parallel...")
 
     critiques: dict[str, str] = {}
@@ -227,7 +271,7 @@ def main() -> int:
                 else ""
             )
             prompt = build_prompt(body, source_label, source_text, extra=extra)
-            futures[pool.submit(call_gemini, model_client, args.model, prompt)] = name
+            futures[pool.submit(call_gemini, model_client, args.model, prompt, budget)] = name
         for fut in as_completed(futures):
             name = futures[fut]
             critiques[name] = fut.result()
@@ -245,10 +289,19 @@ def main() -> int:
     for name, text in sorted(critiques.items()):
         synthesis_payload += f"\n### {name}\n{text}\n"
     lead_prompt = build_prompt(lead_body, source_label, synthesis_payload)
-    synthesis = call_gemini(model_client, args.model, lead_prompt)
+    synthesis = call_gemini(model_client, args.model, lead_prompt, budget)
+    used, cap = budget.snapshot()
+    print(f"[council] Requests consumed: {used}/{cap}")
 
     ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
-    report = [f"# Council report — {ts}", "", f"**Source:** {source_label}", "", "## Scores"]
+    report = [
+        f"# Council report — {ts}",
+        "",
+        f"**Source:** {source_label}",
+        f"**Requests:** {used}/{cap}",
+        "",
+        "## Scores",
+    ]
     for name in sorted(critiques):
         score = scores[name]
         report.append(f"- `{name}`: {score if score is not None else 'n/a'}")
@@ -271,6 +324,8 @@ def main() -> int:
             "source": source_label,
             "model": args.model,
             "scores": scores,
+            "requests_used": used,
+            "requests_cap": cap,
         }
     )
     update_session_state_council(scores, source_label)


### PR DESCRIPTION
## Summary

Addresses both Codex review comments from PR #1.

- **P1 — request budget includes retries.** Introduced `RequestBudget`, a thread-safe counter consulted before every `call_gemini` attempt (initial + retries). Previously the cap only counted *planned* calls, so 7 personas × up to 2 retries each could fire 21 actual API requests against a 15-call hard limit. Now exhausted attempts return a graceful skip message instead of silently blowing past the budget.
- **P2 — `--diff` recovers when base ref is missing.** `git diff origin/main...HEAD` now falls back to `git diff HEAD` (working tree) instead of dying when the base ref is unavailable. Common in fresh clones or forks before `main` has been fetched. Warning printed to stderr so users know what happened.
- Bonus: request consumption (`used/cap`) now appears in the council report header and the `yolo_log.jsonl` entry for ongoing cost tracking.

## Test plan

- [ ] `python3 .harness/scripts/council.py` with `GEMINI_API_KEY` unset still errors cleanly (verified locally).
- [ ] `python3 .harness/scripts/council.py --diff` works in a clone where `origin/main` exists.
- [ ] `python3 .harness/scripts/council.py --diff` falls back to working-tree diff when `origin/main` does not exist (warning to stderr, no crash).
- [ ] Force a Gemini retry (e.g. by temporarily breaking the API key mid-run); confirm the budget snapshot at the end equals the cap and skipped calls return the budget-exhausted message.
- [ ] `last_council.md` shows `**Requests:** N/15` in the header.

https://claude.ai/code/session_01Qko6i8YW7uYQcGTA98WQrA