### PR TITLE
[skip council] chore(diag): add static /diag control page for blank-page debug

### DIFF
--- a/apps/web/app/diag/page.tsx
+++ b/apps/web/app/diag/page.tsx
@@ -1,0 +1,36 @@
+// Diagnostic page — pure server component, zero client-side JS, no imports
+// from workspace packages. If this route renders but /auth doesn't, the
+// bug lives in the /auth page's client component or one of its imports.
+// If this one also goes blank, the issue is in the layout, the framework
+// wiring, or the browser/network environment.
+//
+// Temporary; remove once blank-page issue is root-caused.
+
+export const dynamic = 'force-static';
+
+export default function DiagPage() {
+  return (
+    <div
+      style={{
+        padding: '1rem',
+        fontFamily: 'system-ui, sans-serif',
+        fontSize: '16px',
+        color: '#000',
+        background: '#fff',
+      }}
+    >
+      <h1 style={{ fontSize: '20px', fontWeight: 'bold' }}>diag: server component OK</h1>
+      <p>
+        If you can read this sentence, Vercel is serving valid HTML and your browser is
+        rendering it.
+      </p>
+      <ul>
+        <li>server-rendered time: {new Date().toISOString()}</li>
+        <li>node version: {process.version}</li>
+      </ul>
+      <p>
+        Next test: visit <a href="/auth">/auth</a> and compare.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Diagnostic control — isolate the blank-page bug

After PR #9's error boundaries deployed, `/auth` is still rendering blank on
user's mobile browser. The error boundaries didn't trigger → React didn't
crash → something else is wiping the DOM.

This adds a pure server component at `/diag` with:
- Zero client-side JS (`export const dynamic = 'force-static'`)
- Zero imports from workspace packages
- Inline styles only (no Tailwind dep)

**Test**:
- If `/diag` renders normally → bug is in `/auth` page code, most likely
  the `supabaseBrowser()` import path or Supabase SSR initialization.
- If `/diag` also goes blank → bug is in `layout.tsx`, global CSS, or
  the browser environment (service worker, aggressive cache).

`[skip council]` — active incident diagnostic.

## Test plan
- [ ] Merge + wait for Vercel auto-deploy.
- [ ] User visits `/diag` on mobile.
- [ ] Report: does the "diag: server component OK" heading appear?

https://claude.ai/code/session_01P9e6ZVXdroWpzjUhpFDAuv