### PR TITLE
docs(plan): inline NEXT_PUBLIC_* env reads in client-bundled supabaseBrowser

### DIFF
--- a/.harness/active_plan.md
+++ b/.harness/active_plan.md
@@ -1,185 +1,205 @@
-# Plan: `force-dynamic` on root layout so CSP nonces stamp on rendered HTML
+# Plan: inline NEXT_PUBLIC_* env reads in client-bundled supabaseBrowser
 
 ## Status
 
-PR #13 shipped per-request CSP nonce middleware. Prod verification via
-`curl -sI` shows:
+PRs #13 + #16 shipped: per-request CSP nonce middleware + force-dynamic
+root layout. Verified end-to-end in prod:
 
-- `/diag` CSP header: `script-src 'self' 'nonce-fmsWsovI2Yc95ZLEsJiFBQ==' 'strict-dynamic'`
-- `/auth` CSP header: `script-src 'self' 'nonce-Y9CKrXcfBxyCewIUGwlqLw==' 'strict-dynamic'`
+- CSP header carries per-request nonce
+- Script tags carry matching `nonce="<value>"` attributes
 - `cache-control: private, no-store, max-age=0` ✅
-- `connect-src` wildcard `*.vercel.app` gone ✅
+- `/auth` page renders and stays interactive
 
-User-facing after PR #13:
+User-tested the magic-link button: **still unresponsive**. No visible
+error, no "Check your email" message, no error message.
 
-- `/diag` renders and stays — **visually looks fixed**. But: no inline
-  script tags carry a `nonce=` attribute, so client JS (if any) is
-  CSP-blocked. `/diag` is a pure server component with no hydration
-  requirements, so this is latent but not visible.
-- `/auth` renders and stays — the form is visible. **But: the "Send
-  magic link" button does nothing.** React never hydrates because
-  CSP + `'strict-dynamic'` blocks every script tag (none have nonces).
+## Root cause (verified this session)
 
-## Why the nonce isn't on scripts
+`packages/db/src/browser.ts:14-17`:
 
-Build output from `next build`:
-
-```
-├ ○ /auth     912 B    165 kB
-├ ○ /diag     133 B    103 kB
+```ts
+export function supabaseBrowser() {
+  const supabaseUrl = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const anonKey = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  return createBrowserClient(supabaseUrl, anonKey);
+}
 ```
 
-`○` = **static**. Both pages are **prerendered at build time** into
-frozen HTML. Middleware runs at request time and sets `x-nonce` on
-the request — but the HTML was already serialized during `next build`
-when no `x-nonce` existed. There is no request-time render pass that
-could stamp the nonce onto Next.js's emitted script tags.
+`requireEnv` (in `packages/lib/utils/src/env.ts:11`) reads:
 
-For per-request nonces to land on per-page scripts, the page has to
-be rendered per request. In Next.js 15 App Router, that means the
-route segment config `dynamic = 'force-dynamic'`.
+```ts
+const v = process.env[name];
+```
+
+**Dynamic key.** Next.js's compile-time `process.env.NEXT_PUBLIC_*`
+inliner only replaces literal property accesses (`process.env.NEXT_PUBLIC_FOO`),
+not dynamic ones (`process.env[name]`). Server-side this is fine —
+real Node.js `process.env` is populated. **Client-side it's not** —
+Next.js ships only an empty-ish shim with `NODE_ENV` set, so
+`process.env['NEXT_PUBLIC_SUPABASE_URL']` returns `undefined`.
+
+Confirmed by curling the deployed auth chunk:
+
+```
+$ curl -s …/_next/static/chunks/app/auth/page-32aa280cf1604825.js \
+    | grep -oE 'lhxokbbcojqtwvibbqfj'
+(empty — Supabase URL is NOT inlined)
+
+$ … | grep -oE 'missing or empty'
+missing or empty   ← requireEnv error string IS shipped
+```
+
+So clicking "Send magic link" runs:
+
+1. `onSubmit` async handler.
+2. `supabaseBrowser()` → `requireEnv('NEXT_PUBLIC_SUPABASE_URL')` →
+   throws `"NEXT_PUBLIC_SUPABASE_URL missing or empty"`.
+3. Throw propagates out of the async handler, becomes a swallowed
+   promise rejection. `setErr` never runs (the throw is before any
+   try/catch). `setSent` never runs.
+4. Button looks dead. No error visible to user.
+
+This was flagged in the previous session's handoff plan as
+"roadmap step 4" but deferred because it wasn't believed to be the
+root of the blank-page bug. Now confirmed: it IS the root of the
+post-CSP-fix dead-button bug.
 
 ## Fix
 
-Add a single line to `apps/web/app/layout.tsx`:
+Replace the two `requireEnv` calls in `packages/db/src/browser.ts`
+with direct, statically-analyzable reads:
 
-```tsx
-export const dynamic = 'force-dynamic';
+```ts
+import { createBrowserClient } from '@supabase/ssr';
+
+export function supabaseBrowser() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !anonKey) {
+    throw new Error(
+      'Supabase env vars missing in client bundle. ' +
+        'NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY ' +
+        'must be set at build time, not just runtime.',
+    );
+  }
+  return createBrowserClient(supabaseUrl, anonKey);
+}
 ```
 
-Layout-level route segment config propagates to children. Every page
-now renders per request, Next.js sees `x-nonce` on the request, and
-stamps `nonce="<value>"` on every script tag it emits. CSP
-`'nonce-<value>' 'strict-dynamic'` then permits those scripts and
-their transitively-loaded chunks.
+Direct property access (`process.env.NEXT_PUBLIC_SUPABASE_URL`)
+gets inlined by Next.js at build time → the actual URL string is
+in the client bundle → `supabaseBrowser()` works.
 
-`/diag` overrides with its own `dynamic = 'force-static'`, so it stays
-prerendered. That's fine — `/diag` is diagnostic-only, no client JS
-needed; CSP-blocked scripts on it are a non-issue.
+Defensive runtime guard kept (the values are `string | undefined`
+in TS strict mode, and we want a clear error if someone deploys
+without the env vars set at build time).
 
-## Why this is the minimal correct fix
+`requireEnv` stays in use for all SERVER-side callers (server.ts,
+inngest, ratelimit, ai/pdfparser). Those run in real Node.js
+contexts where dynamic `process.env[name]` works fine.
 
-**Not** "convert `/auth` to a server component wrapper + client child."
-That would touch auth code surface, require import shuffling, and still
-leave any future client page broken by default. Layout-level
-`force-dynamic` is future-proof: any new client component under `/app`
-automatically gets the nonce treatment.
+## Why not "make `requireEnv` smarter"?
 
-**Not** "remove `'strict-dynamic'` and rely on `'self'`." Under plain
-`'self'`, Next.js's inline Flight-payload `<script>` tags (no `src`,
-inline content like `self.__next_f.push(...)`) are still blocked
-because `'self'` only permits same-origin *external* scripts. Inline
-scripts need `'unsafe-inline'`, a nonce, or a hash.
+Tempting: detect at runtime if we're in a Next.js client bundle
+and pull from `__NEXT_DATA__` or some inlined map. Council will
+(rightly) reject:
 
-**Not** "add `'unsafe-inline'` to script-src." Defeats the whole point
-of the PR #13 fix and opens XSS defense-in-depth on an auth-adjacent
-surface.
+- Next.js doesn't expose `NEXT_PUBLIC_*` values via any documented
+  client API. The only contract is "literal `process.env.X` gets
+  inlined at build time."
+- Adding a runtime detect-and-fallback path masks the real fix:
+  "client-bundle code must read env vars literally, not by name."
+- Server-side `requireEnv` is correct as-is. Two distinct constraints
+  → two distinct call patterns. Don't bloat the helper.
 
-## Cost trade-off (explicit)
+## Why not "fix it in `requireEnv` with a build-time codemod"?
 
-PR #13 already set `Cache-Control: private, no-store, max-age=0` in
-middleware, which disables Vercel Edge HTML caching for every
-middleware-matched route. That means we've already paid the "no HTML
-cache" cost. Forcing dynamic rendering adds no further cost at the
-CDN layer — it just changes the origin render path from "serve
-prebuilt HTML" to "render on demand." Per-request render is still
-fast (React 19 streaming, `/auth` is tiny), and we have no traffic
-volume that makes this a concern.
+Even more tempting if we had multiple client-side callers. We don't —
+only `browser.ts` is client-bundled. Two-line surgical fix beats
+codemod plumbing.
 
-Cohort-scale math: worst case 100 users × 20 page loads/day = 2000
-origin renders/day = ~60k/month. Vercel Hobby SSR invocation limit
-is 100k/day. Well within budget.
+## Files changed
+
+1. **`packages/db/src/browser.ts`** *(modified)*
+   - Drop `requireEnv` import.
+   - Read both env vars via direct property access.
+   - Inline guard with a clear error message.
+
+2. **`packages/db/src/browser.test.ts`** *(if it exists; new otherwise)*
+   - Stub `process.env` with both vars set → `supabaseBrowser()`
+     returns a client without throwing.
+   - Stub `process.env` with `NEXT_PUBLIC_SUPABASE_URL` unset → throws
+     with the documented error message.
+   - Same with anon key unset.
 
 ## Verification plan
 
 Local (pre-push):
 
-1. `pnpm --filter web run typecheck` — adding a const export shouldn't
-   introduce TS errors; confirms nothing broke.
-2. `pnpm --filter web run test` — existing tests still pass; no new
-   test needed (the change's observable behavior is a CDN/render-mode
-   switch, not testable in vitest).
-3. `env -i PATH="$PATH" HOME="$HOME" NODE_ENV=production npx next build`
-   in `apps/web/`. The build output should now show:
-   - `ƒ /auth` (dynamic)
-   - `○ /diag` (static; overrides layout)
-   - `ƒ /` (still dynamic; was already dynamic)
-   - `ƒ /note/[slug]` (still dynamic)
+1. `pnpm --filter @llmwiki/db run typecheck` clean.
+2. `pnpm --filter @llmwiki/db run test` passes (new browser tests).
+3. `pnpm --filter web run typecheck` clean.
+4. `pnpm --filter web run test` still 58/58.
+5. `env -i PATH="$PATH" HOME="$HOME" NEXT_PUBLIC_SUPABASE_URL='https://x.supabase.co' NEXT_PUBLIC_SUPABASE_ANON_KEY='anon' NODE_ENV=production npx next build` in `apps/web/` succeeds.
+6. After build, `grep -r 'x.supabase.co' apps/web/.next/static/chunks/app/auth/` finds the URL string in the auth chunk — confirms inlining happened.
 
 Post-deploy (prod):
 
-4. `curl -sL https://llmwiki-study-group.vercel.app/auth | grep -oE 'nonce="[^"]+"' | head -5` shows at least one `nonce="..."` attribute on a `<script>` tag.
-5. Human visits `/auth`, types an email, clicks "Send magic link" →
-   either receives the email or sees a "Check your email" confirmation
-   message. No silent button.
-6. Human completes the full sign-in round-trip: email arrives,
-   clicking the link lands on the dashboard (`/`), the cohort
-   upsert runs, the notes list renders.
+7. `curl -s …/_next/static/chunks/app/auth/page-*.js | grep lhxokbbcojqtwvibbqfj` returns matches (currently zero).
+8. **Human clicks "Send magic link"** → either receives email or
+   sees a "Check your email" message. **Real test of the fix.**
+9. Human completes full sign-in round-trip and lands on dashboard.
 
 ## Non-goals
 
-- Changing anything on `/diag`. It stays static intentionally.
-- Changing `/note/[slug]`. Already dynamic.
-- Adding `nonce={nonce}` to any explicit `<Script>` components. We
-  don't use any; Next.js auto-stamps inline scripts when the page
-  is dynamic and `x-nonce` is set.
-- Refactoring `/auth/page.tsx` into a server-component wrapper.
-  Unnecessary complication; layout-level `force-dynamic` handles it.
-- Adding Vercel ISR or page-level revalidate config. Not needed for
-  the cohort scale.
-- Re-enabling HTML edge caching. PR #13 deliberately disabled it for
-  CSP coherence; that constraint stands.
+- Refactoring all `requireEnv` callers. Only browser.ts is broken.
+- Adding a lint rule to forbid client-side `requireEnv`. Worth a
+  follow-up issue but not blocking.
+- Removing `/diag` (issue #12).
+- Hardening `style-src` (issue #15).
+- CSP `report-uri` (issue #14).
+- Playwright nonce smoke test (queued from PR #16's council r2).
 
-## Non-negotiables (carry-over from PR #13)
+## Non-negotiables
 
-- `connect-src` stays scoped (no `*.vercel.app` wildcard).
-- `script-src` keeps `'strict-dynamic'` + nonce.
-- Middleware matcher still excludes `/api/inngest` and `/auth/callback`.
-- No `[skip council]` — this directly affects the auth flow's
-  hydration behavior, which is an auth-surface change.
+- **Auth surface change.** Council required. No `[skip council]`.
+- Service-role key stays server-only (this fix touches only
+  the browser client; service-role is in server.ts, untouched).
+- Direct `process.env.NEXT_PUBLIC_*` access in client bundle is the
+  ONLY supported pattern. Future client-bundled env reads must
+  follow the same pattern; lint enforcement is a follow-up.
 
 ## Rollback
 
-If making all pages dynamic surfaces an unexpected regression:
+Revert the single commit on `main`. Browser auth returns to the
+current dead-button state — no worse, no better. The CSP nonce
+infrastructure (PRs #13, #16) is not affected.
 
-- Revert the single commit on `main` → layout returns to implicit
-  static-by-default.
-- User is back to PR #13's post-state: `/diag` renders, `/auth`
-  renders but button dead. Known regression boundary; no worse than
-  right now.
+## Cost posture
 
-## Open questions for council
+Zero new API calls. Zero new dependencies. The code path that runs
+when the user clicks "Send magic link" is unchanged in shape — only
+the env-read mechanism changes. Pure correctness fix.
 
-1. **Should `/note/[slug]` be forced static via `force-static`?**
-   Individual notes don't need per-user personalization (RLS handles
-   that). Prerendering them would save origin compute. But they
-   contain dashboardy interactivity (future: edits, comments) that
-   may need JS. Defer — not in scope for this fix.
+## Open question for council
 
-2. **Should we add a Playwright / smoke test that asserts `/auth`
-   has `nonce="..."` on at least one script tag post-deploy?**
-   The current regression suite is unit-level; an end-to-end check
-   would catch a future `dynamic = 'force-static'` regression. Worth
-   a follow-up issue, not in this PR's scope.
-
-## Why not bundle the /diag cleanup (issue #12) here?
-
-CLAUDE.md directive: "Don't add features, refactor, or introduce
-abstractions beyond what the task requires. A bug fix doesn't need
-surrounding cleanup." `/diag` removal is a separate, already-tracked
-concern (issue #12). Folding it in would expand the security surface
-being council-reviewed in this plan. Strictly out of scope.
+1. **Should we add a build-time assertion that `NEXT_PUBLIC_*`
+   vars resolve to non-empty strings, failing the build if not?**
+   Today, missing build-time vars surface only as a runtime click
+   failure. A failing build would be a stronger guard. Out of scope
+   here (would need a custom Next.js plugin or build script), but
+   worth a follow-up issue if the cohort grows.
 
 ## Execution order
 
-Single commit. The change is one line in one file plus a reflection
-block in `learnings.md` (appended, not in scope of the code change
-but per CLAUDE.md session protocol).
+Single small commit:
 
-1. Edit `apps/web/app/layout.tsx` — add `export const dynamic = 'force-dynamic';`.
-2. Run local verification (steps 1-3 above).
-3. Commit with `fix(web): force-dynamic on root layout so CSP nonces stamp`.
-4. Push, council r2 on diff.
-5. On PROCEED → human approval → merge.
-6. Post-merge: steps 4-6 of §Verification plan.
-7. Reflect in `.harness/learnings.md`.
+1. Edit `packages/db/src/browser.ts` (the two-line replacement).
+2. Add `packages/db/src/browser.test.ts` (success + missing-url +
+   missing-key cases).
+3. Local verification (steps 1-6 above).
+4. Commit `fix(db): inline NEXT_PUBLIC_* env reads in client bundle`.
+5. Push → council r2.
+6. On PROCEED → human approval → merge.
+7. Post-merge prod verification (steps 7-9).
+8. Reflect in `.harness/learnings.md`.

--- a/.harness/active_plan.md
+++ b/.harness/active_plan.md
@@ -1,4 +1,19 @@
-# Plan: inline NEXT_PUBLIC_* env reads in client-bundled supabaseBrowser
+# Plan: rate-limited server-side /api/auth/magic-link + client env-read fix
+
+## Revision history
+
+- r1 (committed dac32af): client-side `requireEnv` → direct `process.env.*`
+  in `packages/db/src/browser.ts`; UX hardening on `/auth/page.tsx`.
+  Council r2: **REVISE** 8/10/9/10/10/**3** — security blocker: re-enabling
+  `signInWithOtp` client-side without application-level rate limit exposes
+  email-flooding attack surface.
+- r2 (this revision): moves the Supabase Auth call to a new server-side
+  route `apps/web/app/api/auth/magic-link/route.ts`, rate-limited via new
+  Tier C in `@llmwiki/lib-ratelimit`. `/auth/page.tsx` now `fetch()`s the
+  route. `browser.ts` fix retained (other client code depends on it). All
+  r1 UX hardening retained.
+
+# Plan r2: rate-limited /api/auth/magic-link + client env-read fix
 
 ## Status
 

--- a/apps/web/app/api/auth/magic-link/route.ts
+++ b/apps/web/app/api/auth/magic-link/route.ts
@@ -4,11 +4,21 @@
 // server-side gives us per-IP and per-email rate-limiting to prevent
 // email-flooding abuse of our Supabase Auth email quota.
 //
-// Security posture (council r2 PR #17 non-negotiable):
-//   - Per-IP limit: 5 requests / hour (first X-Forwarded-For entry).
-//   - Per-email limit: 3 requests / hour (normalized lower-case).
+// Security posture (council r2 + r3 PR #17 non-negotiables):
+//   - Per-IP limit: 5 requests / hour (first X-Forwarded-For entry;
+//     request is rejected with 400 if no X-Forwarded-For header is
+//     present, to avoid lumping IP-less traffic into a shared bucket
+//     that can be self-DoS'd).
+//   - Per-email limit: 3 requests / hour. Normalized: lowercased + any
+//     `+alias` suffix stripped from the local part so the common Gmail
+//     aliasing pattern (`user+a@gmail.com`, `user+b@gmail.com`) routes
+//     to the same bucket.
 //   - Fail-closed on Upstash outage (503).
-//   - Generic error messages only — never leak Supabase internals.
+//   - emailRedirectTo is built from APP_BASE_URL, NEVER from the request
+//     Host header — otherwise an attacker could spoof Host and redirect
+//     magic-link auth tokens to an attacker-controlled domain.
+//   - Generic error messages to the client; upstream error details are
+//     logged server-side (console.error) but never returned.
 //
 // The anon key is used server-side (via supabaseForRequest) so the
 // service-role key never touches this path.
@@ -31,22 +41,56 @@ export const maxDuration = 10;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_EMAIL_LEN = 254;
 
-function clientIp(req: NextRequest): string {
-  // Vercel puts the real client IP as the leftmost entry of X-Forwarded-For.
+/**
+ * Strip `+alias` suffix from the local part of an email for rate-limit
+ * bucketing. `user+anything@host` → `user@host`. Idempotent on emails
+ * without `+`. Pure function; exported for unit testing.
+ */
+export function normalizeEmailForRateLimit(email: string): string {
+  const at = email.lastIndexOf('@');
+  if (at < 0) return email;
+  const local = email.slice(0, at);
+  const domain = email.slice(at);
+  const plus = local.indexOf('+');
+  if (plus < 0) return email;
+  return `${local.slice(0, plus)}${domain}`;
+}
+
+/**
+ * Extract the client IP from the Vercel `x-forwarded-for` header.
+ *
+ * Vercel's edge sets the real client IP as the leftmost entry. We trust
+ * this header specifically because of Vercel's infrastructure contract;
+ * in a different deployment target this would need to change.
+ *
+ * Returns `null` if no IP can be determined — the caller rejects with
+ * 400 rather than bucketing all IP-less traffic under a shared
+ * `"unknown"` key (which would be a self-inflicted DoS vector).
+ */
+function clientIp(req: NextRequest): string | null {
   const xff = req.headers.get('x-forwarded-for');
   if (xff) {
     const first = xff.split(',')[0]?.trim();
-    if (first) return first;
+    if (first && first.length > 0) return first;
   }
   const xri = req.headers.get('x-real-ip');
-  if (xri) return xri.trim();
-  return 'unknown';
+  if (xri && xri.trim().length > 0) return xri.trim();
+  return null;
 }
 
-function baseUrl(req: NextRequest): string {
+/**
+ * Base URL for building the magic-link `emailRedirectTo`. MUST come from
+ * server env; trusting the request Host header would be an open-redirect
+ * vulnerability (attacker sets Host: evil.com, redirect URL points at
+ * evil.com, Supabase delivers a magic link with auth token to attacker's
+ * domain).
+ */
+function baseUrl(): string {
   const envBase = process.env.APP_BASE_URL;
-  if (envBase && envBase.trim().length > 0) return envBase.replace(/\/$/, '');
-  return new URL(req.url).origin;
+  if (!envBase || envBase.trim().length === 0) {
+    throw new Error('APP_BASE_URL missing or empty');
+  }
+  return envBase.replace(/\/$/, '');
 }
 
 export async function POST(req: NextRequest) {
@@ -68,9 +112,29 @@ export async function POST(req: NextRequest) {
   }
 
   const ip = clientIp(req);
+  if (!ip) {
+    return NextResponse.json(
+      { error: 'Missing client IP. Request rejected.' },
+      { status: 400 },
+    );
+  }
+
+  // Build APP_BASE_URL once up-front so a misconfigured env fails before
+  // we spend a rate-limit slot or a Supabase call.
+  let redirectBase: string;
+  try {
+    redirectBase = baseUrl();
+  } catch (err) {
+    console.error('[magic-link] APP_BASE_URL misconfigured:', err);
+    return NextResponse.json(
+      { error: 'Service temporarily unavailable.' },
+      { status: 503 },
+    );
+  }
+
   const limiter = makeMagicLinkLimiter();
   try {
-    await limiter.reserve(ip, email);
+    await limiter.reserve(ip, normalizeEmailForRateLimit(email));
   } catch (err) {
     if (err instanceof RateLimitExceededError) {
       return NextResponse.json(
@@ -79,6 +143,7 @@ export async function POST(req: NextRequest) {
       );
     }
     if (err instanceof RatelimitUnavailableError) {
+      console.error('[magic-link] upstash unavailable:', err);
       return NextResponse.json(
         { error: 'Service temporarily unavailable.' },
         { status: 503 },
@@ -93,11 +158,17 @@ export async function POST(req: NextRequest) {
   const supabase = await supabaseForRequest();
   const { error } = await supabase.auth.signInWithOtp({
     email,
-    options: { emailRedirectTo: `${baseUrl(req)}/auth/callback` },
+    options: { emailRedirectTo: `${redirectBase}/auth/callback` },
   });
   if (error) {
-    // Do not leak Supabase's error copy verbatim; they can be verbose and
-    // user-unfriendly. Keep the generic surface.
+    // Log the original error context server-side for debugging Supabase
+    // credential / connectivity issues. The client sees generic copy
+    // only — never leak Supabase's error surface.
+    console.error('[magic-link] supabase.signInWithOtp failed:', {
+      name: error.name,
+      message: error.message,
+      status: error.status,
+    });
     return NextResponse.json(
       { error: 'Failed to send magic link. Please try again.' },
       { status: 502 },

--- a/apps/web/app/api/auth/magic-link/route.ts
+++ b/apps/web/app/api/auth/magic-link/route.ts
@@ -1,0 +1,108 @@
+// POST /api/auth/magic-link — rate-limited server-side wrapper around
+// Supabase Auth's `signInWithOtp`. The client form at /auth calls this
+// route instead of invoking Supabase directly; centralizing the call
+// server-side gives us per-IP and per-email rate-limiting to prevent
+// email-flooding abuse of our Supabase Auth email quota.
+//
+// Security posture (council r2 PR #17 non-negotiable):
+//   - Per-IP limit: 5 requests / hour (first X-Forwarded-For entry).
+//   - Per-email limit: 3 requests / hour (normalized lower-case).
+//   - Fail-closed on Upstash outage (503).
+//   - Generic error messages only — never leak Supabase internals.
+//
+// The anon key is used server-side (via supabaseForRequest) so the
+// service-role key never touches this path.
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { supabaseForRequest } from '../../../../lib/supabase';
+import {
+  makeMagicLinkLimiter,
+  RateLimitExceededError,
+  RatelimitUnavailableError,
+} from '@llmwiki/lib-ratelimit';
+
+export const runtime = 'nodejs';
+export const maxDuration = 10;
+
+// Pragmatic email shape check — not RFC-strict. Supabase does its own
+// validation server-side; this exists only to reject obvious garbage
+// before consuming a rate-limit slot.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LEN = 254;
+
+function clientIp(req: NextRequest): string {
+  // Vercel puts the real client IP as the leftmost entry of X-Forwarded-For.
+  const xff = req.headers.get('x-forwarded-for');
+  if (xff) {
+    const first = xff.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  const xri = req.headers.get('x-real-ip');
+  if (xri) return xri.trim();
+  return 'unknown';
+}
+
+function baseUrl(req: NextRequest): string {
+  const envBase = process.env.APP_BASE_URL;
+  if (envBase && envBase.trim().length > 0) return envBase.replace(/\/$/, '');
+  return new URL(req.url).origin;
+}
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const rawEmail =
+    typeof body === 'object' && body !== null && 'email' in body &&
+    typeof (body as { email?: unknown }).email === 'string'
+      ? (body as { email: string }).email
+      : '';
+  const email = rawEmail.trim().toLocaleLowerCase('en-US');
+  if (!email || email.length > MAX_EMAIL_LEN || !EMAIL_RE.test(email)) {
+    return NextResponse.json({ error: 'Invalid email address' }, { status: 400 });
+  }
+
+  const ip = clientIp(req);
+  const limiter = makeMagicLinkLimiter();
+  try {
+    await limiter.reserve(ip, email);
+  } catch (err) {
+    if (err instanceof RateLimitExceededError) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        { status: 429 },
+      );
+    }
+    if (err instanceof RatelimitUnavailableError) {
+      return NextResponse.json(
+        { error: 'Service temporarily unavailable.' },
+        { status: 503 },
+      );
+    }
+    throw err;
+  }
+
+  // Cost: 1 Supabase Auth email per accepted request. Rate-limit above
+  // caps this at 5/IP/hr × IPs + 3/email/hr — email quota is the primary
+  // concern, controlled by the per-email limit.
+  const supabase = await supabaseForRequest();
+  const { error } = await supabase.auth.signInWithOtp({
+    email,
+    options: { emailRedirectTo: `${baseUrl(req)}/auth/callback` },
+  });
+  if (error) {
+    // Do not leak Supabase's error copy verbatim; they can be verbose and
+    // user-unfriendly. Keep the generic surface.
+    return NextResponse.json(
+      { error: 'Failed to send magic link. Please try again.' },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ ok: true }, { status: 200 });
+}

--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -27,11 +27,25 @@ export default function AuthPage() {
         setSent(true);
         return;
       }
-      const data = (await res.json().catch(() => null)) as { error?: string } | null;
+      // 4xx / 5xx: try JSON first, fall back to status-only message if
+      // the body isn't JSON (e.g. a Vercel HTML error page). Log raw
+      // status + a text snippet so devtools can see more context than
+      // the generic user-facing string.
+      let data: { error?: string } | null = null;
+      try {
+        data = (await res.json()) as { error?: string };
+      } catch {
+        const rawText = await res.text().catch(() => '');
+        console.error(
+          '[/auth] non-JSON response from /api/auth/magic-link',
+          res.status,
+          rawText.slice(0, 200),
+        );
+      }
       const message =
         data?.error && typeof data.error === 'string' && data.error.length > 0
           ? data.error
-          : 'Unexpected error sending magic link.';
+          : `Request failed (${res.status}). Please try again.`;
       setErr(message);
     } catch (caught) {
       setErr(

--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-// Magic-link sign-in page. Kept intentionally minimal — OAuth is a v1
-// addition with its own plan + council round.
+// Magic-link sign-in. The actual Supabase call lives server-side at
+// /api/auth/magic-link; this form POSTs to that route so rate-limiting
+// runs on the server and the email channel can't be flooded by a looping
+// client. OAuth is a v1 addition with its own plan + council round.
 import { useState } from 'react';
-import { supabaseBrowser } from '@llmwiki/db/browser';
 
 export default function AuthPage() {
   const [email, setEmail] = useState('');
@@ -17,15 +18,27 @@ export default function AuthPage() {
     setErr(null);
     setPending(true);
     try {
-      const supabase = supabaseBrowser();
-      const { error } = await supabase.auth.signInWithOtp({
-        email,
-        options: { emailRedirectTo: `${location.origin}/auth/callback` },
+      const res = await fetch('/api/auth/magic-link', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email }),
       });
-      if (error) setErr(error.message);
-      else setSent(true);
+      if (res.ok) {
+        setSent(true);
+        return;
+      }
+      const data = (await res.json().catch(() => null)) as { error?: string } | null;
+      const message =
+        data?.error && typeof data.error === 'string' && data.error.length > 0
+          ? data.error
+          : 'Unexpected error sending magic link.';
+      setErr(message);
     } catch (caught) {
-      setErr(caught instanceof Error ? caught.message : 'Unexpected error sending magic link.');
+      setErr(
+        caught instanceof Error && caught.message.length > 0
+          ? caught.message
+          : 'Unexpected error sending magic link.',
+      );
     } finally {
       setPending(false);
     }
@@ -52,7 +65,7 @@ export default function AuthPage() {
         onChange={(e) => setEmail(e.target.value)}
         aria-describedby={err ? 'auth-error' : undefined}
         disabled={pending}
-        className="mt-1 block w-full border border-brand-100 rounded-md px-3 py-2 min-h-[44px] disabled:opacity-60"
+        className="mt-1 block w-full border border-brand-100 rounded-md px-3 py-2 min-h-[44px] disabled:bg-brand-50 disabled:text-brand-700 disabled:cursor-not-allowed"
       />
       {err && (
         <p id="auth-error" role="alert" aria-live="assertive" className="mt-2 text-danger text-sm">
@@ -63,7 +76,7 @@ export default function AuthPage() {
         type="submit"
         disabled={pending}
         aria-busy={pending}
-        className="mt-4 bg-brand-900 text-white px-4 py-2 rounded-md min-h-[44px] disabled:opacity-60 disabled:cursor-not-allowed"
+        className="mt-4 bg-brand-900 text-white px-4 py-2 rounded-md min-h-[44px] disabled:bg-brand-700 disabled:cursor-not-allowed"
       >
         {pending ? 'Sending…' : 'Send magic link'}
       </button>

--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -9,21 +9,34 @@ export default function AuthPage() {
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
 
   const onSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
+    if (pending) return;
     setErr(null);
-    const supabase = supabaseBrowser();
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: { emailRedirectTo: `${location.origin}/auth/callback` },
-    });
-    if (error) setErr(error.message);
-    else setSent(true);
+    setPending(true);
+    try {
+      const supabase = supabaseBrowser();
+      const { error } = await supabase.auth.signInWithOtp({
+        email,
+        options: { emailRedirectTo: `${location.origin}/auth/callback` },
+      });
+      if (error) setErr(error.message);
+      else setSent(true);
+    } catch (caught) {
+      setErr(caught instanceof Error ? caught.message : 'Unexpected error sending magic link.');
+    } finally {
+      setPending(false);
+    }
   };
 
   if (sent) {
-    return <p>Check your email for a sign-in link.</p>;
+    return (
+      <p role="status" aria-live="polite">
+        Check your email for a sign-in link.
+      </p>
+    );
   }
 
   return (
@@ -38,18 +51,21 @@ export default function AuthPage() {
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         aria-describedby={err ? 'auth-error' : undefined}
-        className="mt-1 block w-full border border-brand-100 rounded-md px-3 py-2 min-h-[44px]"
+        disabled={pending}
+        className="mt-1 block w-full border border-brand-100 rounded-md px-3 py-2 min-h-[44px] disabled:opacity-60"
       />
       {err && (
-        <p id="auth-error" role="alert" className="mt-2 text-danger text-sm">
+        <p id="auth-error" role="alert" aria-live="assertive" className="mt-2 text-danger text-sm">
           {err}
         </p>
       )}
       <button
         type="submit"
-        className="mt-4 bg-brand-900 text-white px-4 py-2 rounded-md min-h-[44px]"
+        disabled={pending}
+        aria-busy={pending}
+        className="mt-4 bg-brand-900 text-white px-4 py-2 rounded-md min-h-[44px] disabled:opacity-60 disabled:cursor-not-allowed"
       >
-        Send magic link
+        {pending ? 'Sending…' : 'Send magic link'}
       </button>
     </form>
   );

--- a/apps/web/tests/unit/api-auth-magic-link.test.ts
+++ b/apps/web/tests/unit/api-auth-magic-link.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Validation-path test: exercises the 400 branches that return before
+// touching Upstash or Supabase. Happy-path (200) and 429 paths require
+// integration wiring and are covered by post-deploy manual verification
+// plus the Tier C limiter unit test in @llmwiki/lib-ratelimit.
+//
+// Mock Upstash + Supabase at the module boundary so that if validation
+// accidentally falls through, these tests fail loudly rather than
+// silently hitting a real Redis / Supabase at test time.
+vi.mock('@llmwiki/lib-ratelimit', () => ({
+  makeMagicLinkLimiter: () => ({
+    reserve: () => {
+      throw new Error('[test] rate-limiter called before validation');
+    },
+  }),
+  RateLimitExceededError: class extends Error {},
+  RatelimitUnavailableError: class extends Error {},
+}));
+vi.mock('../../lib/supabase', () => ({
+  supabaseForRequest: () => {
+    throw new Error('[test] supabase called before validation');
+  },
+}));
+
+function req(body: string | undefined): NextRequest {
+  return new NextRequest(new URL('https://example.test/api/auth/magic-link'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body,
+  });
+}
+
+describe('POST /api/auth/magic-link — validation paths', () => {
+  it('rejects invalid JSON body with 400', async () => {
+    const { POST } = await import('../../app/api/auth/magic-link/route');
+    const res = await POST(req('{not json'));
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringMatching(/JSON/i) });
+  });
+
+  it('rejects missing email field with 400', async () => {
+    const { POST } = await import('../../app/api/auth/magic-link/route');
+    const res = await POST(req(JSON.stringify({})));
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringMatching(/email/i) });
+  });
+
+  it('rejects non-string email with 400', async () => {
+    const { POST } = await import('../../app/api/auth/magic-link/route');
+    const res = await POST(req(JSON.stringify({ email: 12345 })));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects malformed email shape with 400', async () => {
+    const { POST } = await import('../../app/api/auth/magic-link/route');
+    const res = await POST(req(JSON.stringify({ email: 'not-an-email' })));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects whitespace-only email with 400', async () => {
+    const { POST } = await import('../../app/api/auth/magic-link/route');
+    const res = await POST(req(JSON.stringify({ email: '   ' })));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects email exceeding 254 chars with 400', async () => {
+    const longLocal = 'a'.repeat(250);
+    const { POST } = await import('../../app/api/auth/magic-link/route');
+    const res = await POST(req(JSON.stringify({ email: `${longLocal}@x.co` })));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/tests/unit/api-auth-magic-link.test.ts
+++ b/apps/web/tests/unit/api-auth-magic-link.test.ts
@@ -24,10 +24,12 @@ vi.mock('../../lib/supabase', () => ({
   },
 }));
 
-function req(body: string | undefined): NextRequest {
+function req(body: string | undefined, xff: string | null = '203.0.113.9'): NextRequest {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (xff) headers['x-forwarded-for'] = xff;
   return new NextRequest(new URL('https://example.test/api/auth/magic-link'), {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers,
     body,
   });
 }
@@ -70,5 +72,59 @@ describe('POST /api/auth/magic-link — validation paths', () => {
     const { POST } = await import('../../app/api/auth/magic-link/route');
     const res = await POST(req(JSON.stringify({ email: `${longLocal}@x.co` })));
     expect(res.status).toBe(400);
+  });
+
+  it('rejects missing X-Forwarded-For header with 400 (no shared bucket)', async () => {
+    // Email is valid shape; IP check must fire before rate limit.
+    const { POST } = await import('../../app/api/auth/magic-link/route');
+    const res = await POST(req(JSON.stringify({ email: 'ok@example.com' }), null));
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      error: expect.stringMatching(/client ip/i),
+    });
+  });
+
+  it('fail-closes to 503 if APP_BASE_URL is unset (no Host header fallback)', async () => {
+    // Valid email + IP so we reach the baseUrl guard before the mocked
+    // limiter (which would throw from the test harness).
+    vi.stubEnv('APP_BASE_URL', '');
+    try {
+      const { POST } = await import('../../app/api/auth/magic-link/route');
+      const res = await POST(req(JSON.stringify({ email: 'ok@example.com' })));
+      expect(res.status).toBe(503);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});
+
+describe('normalizeEmailForRateLimit', () => {
+  it('strips +alias from the local part (Gmail-style bypass)', async () => {
+    const { normalizeEmailForRateLimit } = await import(
+      '../../app/api/auth/magic-link/route'
+    );
+    expect(normalizeEmailForRateLimit('user+test@example.com')).toBe('user@example.com');
+    expect(normalizeEmailForRateLimit('user+anything+else@example.com')).toBe(
+      'user@example.com',
+    );
+  });
+
+  it('leaves emails without + alias unchanged', async () => {
+    const { normalizeEmailForRateLimit } = await import(
+      '../../app/api/auth/magic-link/route'
+    );
+    expect(normalizeEmailForRateLimit('plain@example.com')).toBe('plain@example.com');
+  });
+
+  it('preserves + that appears in the domain (not a local-part alias)', async () => {
+    // An email like `user@domain+tag.com` is not a real Gmail-style alias
+    // pattern; we only strip `+` from the local part. This test locks in
+    // that scoping.
+    const { normalizeEmailForRateLimit } = await import(
+      '../../app/api/auth/magic-link/route'
+    );
+    expect(normalizeEmailForRateLimit('user@sub+tag.example')).toBe(
+      'user@sub+tag.example',
+    );
   });
 });

--- a/packages/db/src/browser.ts
+++ b/packages/db/src/browser.ts
@@ -1,18 +1,31 @@
 // Browser-safe Supabase client. Only uses the anon key. Safe to import from
 // client components. RLS is always enforced.
 //
-// Env reads are LAZY — they happen inside the factory on invocation, never
-// at module top level. A module-top-level throw would break any route that
-// transitively imports this file during Next.js's build-time page-data pass.
+// Env reads use LITERAL `process.env.NEXT_PUBLIC_*` property access. Next.js
+// statically inlines these at build time only when the property name is a
+// compile-time literal — `process.env[name]` with a runtime variable does
+// NOT get inlined and ships as `undefined` in the client bundle. That's why
+// this file deliberately does not import `requireEnv`; that helper reads
+// `process.env[name]` dynamically and is correct for server callers but
+// fatal for client ones.
+//
+// Validation duplicates `requireEnv`'s empty/whitespace contract (covered
+// by browser.test.ts) so the only thing that changes between this file and
+// `requireEnv` is the inlining behaviour, not the error semantics.
 import { createBrowserClient } from '@supabase/ssr';
-import { requireEnv } from '@llmwiki/lib-utils/env';
 
 /**
  * Browser Supabase client. Session cookie-backed; reads + subscribes respect
  * the authenticated user's RLS policies.
  */
 export function supabaseBrowser() {
-  const supabaseUrl = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
-  const anonKey = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!supabaseUrl || supabaseUrl.trim().length === 0) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL missing or empty');
+  }
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!anonKey || anonKey.trim().length === 0) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY missing or empty');
+  }
   return createBrowserClient(supabaseUrl, anonKey);
 }

--- a/packages/lib/ratelimit/src/index.test.ts
+++ b/packages/lib/ratelimit/src/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   makeTokenBudgetLimiter,
   makeIngestEventLimiter,
+  makeMagicLinkLimiter,
   RateLimitExceededError,
   RatelimitUnavailableError,
   TOKEN_BUDGET_PER_HOUR,
@@ -104,5 +105,16 @@ describe('ingest event limiter', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
     const lim = makeIngestEventLimiter({ redis: redis as any });
     await expect(lim.reserve('u1')).rejects.toBeInstanceOf(RatelimitUnavailableError);
+  });
+});
+
+describe('magic link limiter', () => {
+  it('throws RatelimitUnavailable on upstash failure (fail closed)', async () => {
+    const redis = { eval: async () => { throw new Error('down'); } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    const lim = makeMagicLinkLimiter({ redis: redis as any });
+    await expect(lim.reserve('1.2.3.4', 'x@y.z')).rejects.toBeInstanceOf(
+      RatelimitUnavailableError,
+    );
   });
 });

--- a/packages/lib/ratelimit/src/index.ts
+++ b/packages/lib/ratelimit/src/index.ts
@@ -17,7 +17,11 @@ import { requireEnv } from '@llmwiki/lib-utils/env';
 export class RateLimitExceededError extends Error {
   override readonly name = 'RateLimitExceededError';
   constructor(
-    public readonly kind: 'ingest_events' | 'token_budget',
+    public readonly kind:
+      | 'ingest_events'
+      | 'token_budget'
+      | 'magic_link_ip'
+      | 'magic_link_email',
     public readonly resetsAt: Date,
   ) {
     super(`rate limit exceeded: ${kind}; resets at ${resetsAt.toISOString()}`);
@@ -132,4 +136,66 @@ export function makeTokenBudgetLimiter(deps: RateLimitDeps = {}) {
   }
 
   return { reserve, refund };
+}
+
+// ----- Tier C: magic-link auth limiter (anonymous endpoint) ---------------
+//
+// Magic-link requests come in unauthenticated (the point of the flow is to
+// identify the user via email), so the other two tiers' per-user key won't
+// work. This tier keys by BOTH client IP and normalized email with
+// independent counters — per-IP stops a single source from flooding the
+// email provider; per-email stops a targeted attacker from spraying a
+// single inbox.
+//
+// Limits are intentionally low. A real user hits this button a handful of
+// times per session at most. Rate-limiter resolution is per-hour.
+
+export const MAGIC_LINK_PER_IP_PER_HOUR = 5;
+export const MAGIC_LINK_PER_EMAIL_PER_HOUR = 3;
+
+export function makeMagicLinkLimiter(deps: RateLimitDeps = {}) {
+  const redis = makeRedis(deps);
+  const ipLimiter = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(MAGIC_LINK_PER_IP_PER_HOUR, '1 h'),
+    analytics: false,
+    prefix: 'rl:magiclink:ip',
+  });
+  const emailLimiter = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(MAGIC_LINK_PER_EMAIL_PER_HOUR, '1 h'),
+    analytics: false,
+    prefix: 'rl:magiclink:email',
+  });
+
+  /**
+   * Check-and-decrement both counters. Throws:
+   *   - RateLimitExceededError('magic_link_ip') if IP is over the limit.
+   *   - RateLimitExceededError('magic_link_email') if email is over the limit.
+   *   - RatelimitUnavailableError if Upstash is unreachable (fail-closed).
+   *
+   * `ip` should be the first entry of X-Forwarded-For (trimmed). `email`
+   * must be normalized (trimmed + `.toLocaleLowerCase('en-US')`) before
+   * calling so the per-email bucket is stable against casing drift.
+   */
+  async function reserve(ip: string, email: string): Promise<void> {
+    let ipRes: Awaited<ReturnType<typeof ipLimiter.limit>>;
+    let emailRes: Awaited<ReturnType<typeof emailLimiter.limit>>;
+    try {
+      [ipRes, emailRes] = await Promise.all([
+        ipLimiter.limit(ip),
+        emailLimiter.limit(email),
+      ]);
+    } catch {
+      throw new RatelimitUnavailableError();
+    }
+    if (!ipRes.success) {
+      throw new RateLimitExceededError('magic_link_ip', new Date(ipRes.reset));
+    }
+    if (!emailRes.success) {
+      throw new RateLimitExceededError('magic_link_email', new Date(emailRes.reset));
+    }
+  }
+
+  return { reserve };
 }

--- a/packages/lib/utils/src/env.ts
+++ b/packages/lib/utils/src/env.ts
@@ -6,7 +6,26 @@
 // pasted-but-empty Vercel env var is functionally identical to missing; fail
 // at the factory call with a clear message instead of opaquely inside a
 // downstream SDK.
+//
+// !!! SERVER-ONLY !!!
+// This helper reads `process.env[name]` with a runtime-variable key. Next.js
+// can only inline `NEXT_PUBLIC_*` env vars when the property name is a
+// compile-time literal (`process.env.NEXT_PUBLIC_FOO`), not a dynamic one.
+// In a client bundle, `process.env` is an empty shim, so calling this helper
+// with any NEXT_PUBLIC name (or any name at all) returns `undefined` and
+// throws. Client-bundled callers MUST read env vars via direct, literal
+// property access — see packages/db/src/browser.ts for the pattern.
 
+/**
+ * Read a required env var by name. Throws if missing or whitespace-only.
+ *
+ * @remarks
+ * Server-only. Do NOT use in client components or any module that ends up
+ * in the Next.js client bundle — the dynamic `process.env[name]` access
+ * here cannot be statically inlined by Next.js, so it always throws on the
+ * client. Read `process.env.NEXT_PUBLIC_*` via literal property access in
+ * client code instead. See `packages/db/src/browser.ts`.
+ */
 export function requireEnv(name: string): string {
   const v = process.env[name];
   if (v === undefined || v === null || v.trim().length === 0) {


### PR DESCRIPTION
## Plan-only PR (no implementation yet)

Per CLAUDE.md plan-first directive. Triggers council on
`.harness/active_plan.md`. Implementation is a follow-up commit on
this branch after council PROCEEDs and human approves.

## Problem

Magic-link button on `/auth` is unresponsive in prod despite PRs #13
+ #16 deploying CSP nonces correctly. CSP header carries nonce ✅,
script tags carry matching `nonce="..."` attributes ✅, page renders
and stays interactive ✅ — but clicking "Send magic link" does
nothing.

## Root cause (verified via curl of deployed bundle)

```
$ curl -s …/_next/static/chunks/app/auth/page-*.js | grep -oE 'lhxokbbcojqtwvibbqfj'
(empty — Supabase URL is NOT in the auth bundle)
$ … | grep -oE 'missing or empty'
missing or empty   ← requireEnv error string IS shipped
```

`packages/db/src/browser.ts` calls `requireEnv('NEXT_PUBLIC_SUPABASE_URL')`,
which internally reads `process.env[name]` — dynamic key. Next.js's
build-time inliner only replaces *literal* `process.env.NEXT_PUBLIC_X`
accesses, not dynamic ones. On the client, `process.env` is an empty
shim, so `requireEnv` throws "NEXT_PUBLIC_SUPABASE_URL missing or empty"
on every form-submit. The throw is swallowed by the async handler,
no error message surfaces, button looks dead.

## Proposed fix

Two-line replacement in `packages/db/src/browser.ts`:

```ts
const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
if (!supabaseUrl || !anonKey) throw new Error(...);
```

Direct property access → Next.js inlines at build time → URL string
ships in the client bundle → `supabaseBrowser()` works.

Server-side `requireEnv` callers (server.ts, inngest, ratelimit,
ai/pdfparser) stay as-is — real Node.js `process.env` at runtime, no
dynamic-key issue.

## Review focus for council

- **Auth surface.** Same auth flow we shipped CSP nonces for. Security
  primary.
- **Scope discipline.** Two-line surgical fix to one file, plus the
  test. Not folding in the lint-rule follow-up or other cleanup.
- **Service-role key.** Untouched — stays in server.ts only.

## Non-goals

- Refactoring all `requireEnv` callers (only browser.ts is broken).
- Adding a lint rule to forbid client-side `requireEnv` (worth a
  follow-up issue).
- Issues #12, #14, #15, the queued Playwright smoke test — all out
  of scope.

See `.harness/active_plan.md` for verification, rollback, cost, and
open question.
