### PR TITLE
fix(auth): PKCE sign-in — cookie-writing client, hardened callback, per-IP rate limit

### DIFF
--- a/.harness/active_plan.md
+++ b/.harness/active_plan.md
@@ -1,244 +1,180 @@
-# Session handoff: CSP + auth fix arc shipped, framework persona is next session's opener
+# Plan: fix auth callback flow (implicit → PKCE + cookie-writing adapter)
 
-## What landed this session
+**Status:** draft, awaiting council + human approval.
+**Branch:** `claude/plan-session-agenda-rRwWN`.
+**Scope:** auth surface — non-negotiable council run required.
+**P0:** without this, no user can complete sign-in.
 
-Three sequential PRs on `main` closing out the production blank-page →
-dead-button bug:
+## Problem
 
-| PR | Commit | Scope |
-|---|---|---|
-| **#13** | `eb707b0` | Per-request CSP nonce via `apps/web/middleware.ts`. Replaced static `script-src 'self'` (which blocked Next.js 15's inline Flight-payload scripts) with nonce + `'strict-dynamic'`. `Cache-Control: private, no-store, max-age=0` to prevent Vercel Edge serving stale HTML with mismatched nonces. Matcher excludes `/api/inngest` and `/auth/callback`. Removed `https://*.vercel.app` wildcard from `connect-src`. Council arc r1→r4 PROCEED. |
-| **#16** | `ffec953` | `export const dynamic = 'force-dynamic'` on `apps/web/app/layout.tsx`. Per-request nonces can't stamp on prerendered HTML (baked at build time before middleware runs); layout-level `force-dynamic` forces every route to render per-request so Next.js reads `x-nonce` and stamps scripts correctly. Note: Next.js's layout-level `force-dynamic` overrides child `force-static`, so `/diag` is now dynamic too (acceptable — no DB calls, no interactivity). |
-| **#17** | `f4fc657` | New rate-limited server-side `apps/web/app/api/auth/magic-link/route.ts`; client `/auth/page.tsx` now `fetch()`es it. `packages/db/src/browser.ts` reads `process.env.NEXT_PUBLIC_*` via literal property access (Next.js can't inline dynamic `process.env[name]`). New Tier C limiter in `@llmwiki/lib-ratelimit` (per-IP 5/hr, per-email 3/hr). Open-redirect protection (required `APP_BASE_URL`, no Host-header fallback). Email alias stripping in rate-limit key. UX hardening on `/auth` (pending state, aria-live regions, "Sending…" copy swap). Council arc r1→r4, two REVISEs (security at r2, bugs at r3) both folded in. |
-
-Verified in prod via curl:
-- CSP header carries per-request nonce.
-- All `<script>` tags carry matching `nonce="..."` attributes.
-- `/api/auth/magic-link` returns 400 on bad JSON, bad email shape,
-  missing email, whitespace-only email, oversize email, missing
-  `x-forwarded-for`.
-- `APP_BASE_URL` confirmed set in Vercel All-Environments.
-- Human tested the button: first deploy (post PR #17) response
-  unverified as of handoff — user to confirm next session.
-
-## Live bug at handoff (verified after merge)
-
-**Symptom:** Magic-link email arrives and looks correct. Clicking the
-"Confirm" link in the email redirects the user back to `/auth` with
-the tokens in a URL fragment:
+First real magic-link email sent after the PR #13/#16/#17 arc landed. The
+email arrives correctly, but clicking the "Confirm" link redirects the
+user back to `/auth` with the session tokens sitting in a URL fragment:
 
 ```
-https://llmwiki-study-group.vercel.app/auth#access_token=<JWT>&expires_at=...&refresh_token=...&token_type=bearer&type=signup
+https://llmwiki-study-group.vercel.app/auth#access_token=<JWT>&expires_at=...&refresh_token=...&type=signup
 ```
 
-Session is NOT persisted — refresh `/auth` and the user is still
-logged out.
+Refreshing `/auth` shows the user still logged out. The session is never
+persisted.
 
-**Root cause (two separate bugs):**
+## Root cause (two bugs stacked)
 
-1. **Flow mismatch — implicit vs PKCE.** Supabase is configured with
-   the default `flowType: 'implicit'` (tokens posted to the URL
-   fragment for client-side JS to parse). Our `/auth/callback`
-   expects `flowType: 'pkce'` (a `?code=...` query param that the
-   server exchanges via `exchangeCodeForSession`). `type=signup` in
-   the fragment also indicates Supabase treated this as a
-   first-time signup, not a returning magic-link sign-in — the
-   "Confirm signup" template runs by default, not "Magic Link". The
-   two templates can be configured separately in the Supabase
-   dashboard.
+1. **Flow mismatch — implicit vs PKCE.** Supabase is on the default
+   `flowType: 'implicit'` (tokens in the URL fragment for client-side
+   parsing). Our `/auth/callback` is written for PKCE (`?code=...` query
+   param + server-side `exchangeCodeForSession`). The email also renders
+   as "Confirm signup" rather than "Magic Link" — both templates can
+   diverge in the Supabase dashboard and both need the PKCE redirect
+   form.
+2. **Cookie adapter is read-only.** `packages/db/src/server.ts:27-34`
+   builds the server client with `@supabase/supabase-js`'s `createClient`
+   and a Cookie-header string. It can READ cookies but has no way to
+   WRITE `Set-Cookie` on the response. Even once PKCE is enabled and
+   `/auth/callback?code=...` fires, `exchangeCodeForSession` succeeds
+   against Supabase Auth and then drops the resulting session on the
+   floor — no cookie is written, so the dashboard's "no session" guard
+   bounces the user straight back to `/auth`.
 
-2. **Cookie adapter is read-only.** Even once PKCE is enabled and
-   `/auth/callback?code=...` gets hit, the existing `supabaseServer`
-   factory (`packages/db/src/server.ts:27-34`) uses
-   `@supabase/supabase-js`'s `createClient` with `persistSession:
-   false` and a cookies-as-string input. It can READ the Cookie
-   header but has no way to WRITE Set-Cookie on the response. So
-   `exchangeCodeForSession` succeeds against Supabase Auth, gets a
-   valid session back, and drops it on the floor. The user bounces
-   right back to `/auth` via the dashboard's "no session → redirect
-   to /auth" guard.
+Both must be fixed together; fixing either alone leaves the user
+broken.
 
-**Fix (all required; TDD order; one PR):**
+## Fix (TDD order, single PR)
 
-A. **Write the failing integration test first.** New file
-   `apps/web/app/auth/callback/route.integration.test.ts` that stubs
-   `exchangeCodeForSession` and asserts, for each branch:
-   - **Success:** response is a 302 to `/`, with a `Set-Cookie`
-     header whose attributes include `HttpOnly`, `Secure`, and
-     `SameSite=Lax`.
-   - **Already-used / expired / network error:** response is a 302
-     to `/auth?error=<kind>` (kind ∈ `token_used`, `token_expired`,
-     `server_error`), NO Set-Cookie, NO session tokens or raw `code`
-     value in any log output (assert via a vi.spy on `console.error`).
-   - **No `code` / empty / whitespace `code`:** 302 to
-     `/auth?error=invalid_request` before any Supabase call is made.
+### A. Failing integration test first
 
-B. In `packages/db/src/server.ts`, add a new factory
-   `createSupabaseClientForRequest(adapter)` that uses `@supabase/ssr`'s
-   `createServerClient` with a full getAll/setAll cookies adapter and
-   `flowType: 'pkce'`. Rename the existing `supabaseServer` to
-   `createSupabaseClientForJobs` (read-only; used by Inngest and
-   cookie-less server contexts) so a future consumer can't silently
-   pick the read-only one for a cookie-writing surface — the council's
-   naming concern. Update all call sites (one-line import swap each).
-   Add a comment block at the top of server.ts explaining which
-   factory to pick and why. Pin the new `@supabase/ssr` dependency
-   version in `packages/db/package.json` + regenerate `pnpm-lock.yaml`.
+New file `apps/web/app/auth/callback/route.integration.test.ts`. Stubs
+`exchangeCodeForSession` and asserts each branch:
 
-C. In `apps/web/lib/supabase.ts`, have `supabaseForRequest()` use
-   `createSupabaseClientForRequest` with the `next/headers`
-   `cookies()` adapter. Wrap `setAll` in try/catch — Server Components
-   can't set cookies; swallow the throw there and let route handlers
-   + server actions write normally.
+- **Success:** 302 to `/`, with a `Set-Cookie` carrying `HttpOnly`,
+  `Secure`, `SameSite=Lax`.
+- **Already-used / expired / server error:** 302 to
+  `/auth?error=<kind>` for `kind ∈ {token_used, token_expired,
+  server_error}`. No `Set-Cookie`. No raw `code`, `access_token`, or
+  `refresh_token` in any `console.error` output (assert via
+  `vi.spyOn(console, 'error')`).
+- **Missing / empty / whitespace `code`:** 302 to
+  `/auth?error=invalid_request` before any Supabase call is made
+  (assert the stub is not invoked).
 
-D. In `apps/web/app/auth/callback/route.ts`, explicitly catch
-   `exchangeCodeForSession` failures. Map known Supabase error shapes
-   to error kinds (`token_used` if the code was consumed,
-   `token_expired` if the code is past TTL, `server_error` for
-   5xx / network). DO NOT log the incoming `code` query parameter,
-   the `access_token`, or the `refresh_token` under any branch. DO
-   log the error kind + sanitized error message (Supabase error kind,
-   no tokens). Redirect to `/auth?error=<kind>` on any failure.
+### B. New cookie-writing factory in `packages/db/src/server.ts`
 
-E. In `apps/web/app/auth/page.tsx`, read the `?error=` query param
-   (via `useSearchParams`) and render an `aria-live="assertive"`
-   error message with a kind-specific copy:
-   - `token_used` → "This sign-in link has already been used. Request a new one."
-   - `token_expired` → "This sign-in link has expired. Request a new one."
-   - `server_error` → "Could not sign you in right now. Please try again."
-   - `invalid_request` → "Sign-in link was invalid. Request a new one."
-   The form remains visible below so the user can request a fresh
-   link without extra clicks.
+Rename the existing read-only `supabaseServer` → `createSupabaseClientForJobs`
+(Inngest + cookie-less server contexts). Add
+`createSupabaseClientForRequest(adapter)` using `@supabase/ssr`'s
+`createServerClient` with a full `getAll` / `setAll` cookies adapter and
+`flowType: 'pkce'`. Header comment in `server.ts` documenting when to
+pick which — prevents a future consumer from silently re-using the
+read-only factory on a cookie-writing surface (council's naming
+concern).
 
-F. In the Supabase dashboard:
-   1. **Authentication → URL Configuration → Redirect URLs allowlist:**
-      confirm it contains ONLY `https://llmwiki-study-group.vercel.app/auth/callback`
-      + any preview-URL pattern. Remove any wildcards or non-project
-      origins. This is the open-redirect guard that complements the
-      server-side `APP_BASE_URL`-only policy in PR #17's magic-link
-      route.
-   2. **Authentication → Email Templates → Confirm signup + Magic
-      Link:** both must use the PKCE redirect URL format,
-      `{{ .SiteURL }}/auth/callback?code={{ .TokenHash }}`. Default
-      templates send tokens in the URL fragment; PKCE requires the
-      code-query form. Verify and fix both templates.
-   3. Screenshot both dashboard sections and attach them to the PR
-      description as the pre-merge verification.
+Update all call sites (one-line import swap each).
 
-G. Update `README.md` "Deploy runbook" with the §F dashboard steps so
-   the checklist catches this in future environments.
+Pin `@supabase/ssr` in `packages/db/package.json`; regenerate
+`pnpm-lock.yaml`.
 
-**Rollback:** Revert the PR. User is back to current state (email
-delivers, but sign-in never completes). No additional regressions.
+### C. Wire the Next.js adapter in `apps/web/lib/supabase.ts`
 
-**Why this was never caught until now:** The magic-link button itself
-was broken all session (PRs #13 → #17 were fixing the send side).
-This is the FIRST successful magic-link email we've ever sent, so the
-callback flow has been untested since v0 scaffold (PR #5).
+`supabaseForRequest()` calls `createSupabaseClientForRequest` with the
+`next/headers` `cookies()` adapter. Wrap `setAll` in try/catch —
+Server Components can't set cookies (Next throws), so swallow that
+throw at the Server-Component call site; route handlers and server
+actions write normally.
 
-## Non-negotiables for the next session's fix PR
+### D. Harden `apps/web/app/auth/callback/route.ts`
 
-Council r1 on PR #21 spelled these out explicitly; re-stated here so
-the fix PR's plan can mark them as already-inherited constraints:
+Catch `exchangeCodeForSession` failures explicitly. Map known Supabase
+error shapes to kinds:
 
-- **No logging of `code` or session tokens.** Server-side logs must
-  redact both under every branch.
-- **Pin the `@supabase/ssr` version.** New dependency, lockfile must
-  reflect the pinned version.
-- **Supabase Redirect URLs allowlist** locked to `APP_BASE_URL`
-  before merge. Screenshot attached to PR description.
-- **Callback errors surface as user-facing messages**, not silent
-  redirects.
-- **Auth surface → council required.** No `[skip council]`.
+- consumed code → `token_used`
+- expired code → `token_expired`
+- 5xx / network → `server_error`
 
-## Next session's opener (priority order)
+**Logging rules (non-negotiable):** never log `code`, `access_token`,
+or `refresh_token` under any branch. Log only the error kind + a
+sanitized Supabase error message. Redirect to `/auth?error=<kind>` on
+every failure branch.
 
-### 1. Fix the callback flow (implicit → PKCE + cookie adapter)
+### E. Surface the error on `/auth/page.tsx`
 
-See §Live bug at handoff above for the full diagnosis. This is the
-P0: without it, no user can complete a sign-in. Fix is auth surface
-→ plan + council required. Scope ~30-50 LoC across two files plus a
-Supabase dashboard config change.
+Read `?error=` via `useSearchParams`; render an `aria-live="assertive"`
+message with kind-specific copy:
 
-### 2. Framework specialist council persona (issue #18)
+- `token_used` → "This sign-in link has already been used. Request a new one."
+- `token_expired` → "This sign-in link has expired. Request a new one."
+- `server_error` → "Could not sign you in right now. Please try again."
+- `invalid_request` → "Sign-in link was invalid. Request a new one."
 
-**Why:** Three sequential PRs this session all landed on
-Next.js / Vercel framework-boundary issues (static vs dynamic rendering;
-middleware vs prerender timing; client-bundle inlining semantics). The
-existing six personas (a11y, arch, bugs, cost, product, security) reason
-about general code quality, not framework-specific footguns. Adding a
-seventh persona collapses the three-PR arc into one. Would ideally
-also catch the callback bug above before it hits production.
+Form stays visible below the message so the user can request a fresh
+link without extra clicks.
 
-Draft `.harness/council/framework.md` covering:
-- App Router static vs dynamic (`○` vs `ƒ`) and how it interacts with
-  middleware / cookies / headers / CSP.
-- Build-time vs runtime `process.env` access (literal vs dynamic).
-- Edge runtime vs Node.js runtime differences.
-- Hydration error reach (async / pre-hydration failures bypass
-  `error.tsx`).
-- RSC / Flight payload flow and inline-script nonce stamping.
-- Cache-Control × Vercel Edge interaction.
-- `NEXT_PUBLIC_` prefix semantics (the "accidental client secret"
-  class).
-- Server Component vs Client Component module-graph implications
-  (`server-only`, `'use client'`).
+### F. Supabase dashboard (manual, pre-merge)
 
-Include an explicit escape hatch: "if this diff does not touch
-Next.js / Vercel / React-server semantics, return `Score: 10` and
-`No framework concerns.`" — mitigates noise on DB migrations, pure
-styling changes, etc.
+1. **Auth → URL Configuration → Redirect URLs allowlist:** only
+   `https://llmwiki-study-group.vercel.app/auth/callback` plus any
+   preview-URL pattern. No wildcards, no non-project origins.
+   Complements PR #17's `APP_BASE_URL`-only server policy.
+2. **Auth → Email Templates → Confirm signup AND Magic Link:** both
+   must use `{{ .SiteURL }}/auth/callback?code={{ .TokenHash }}` (PKCE
+   form). Default templates still carry the fragment form; both
+   templates need editing.
+3. Screenshot both sections; attach to the PR description as
+   pre-merge verification.
 
-Plan → PR → council r1 (the persona file is the thing being reviewed,
-so r1 will be self-referential but that's fine) → human approval →
-merge. `council.py` glob already scans `.harness/council/*.md` so no
-wiring change needed.
+### G. Runbook update
 
-### 3. Complete the sign-in → dashboard round trip
+Add §F to `README.md` "Deploy runbook" so the dashboard steps are in
+the checklist for any future environment.
 
-Once the button works:
-- Click magic link in email.
-- Land on `/auth/callback` (redirect-only route, excluded from
-  middleware).
-- Session cookie set; redirect to `/`.
-- Dashboard renders (cohort upsert, notes list, ingestion jobs).
-- Test a PDF upload end-to-end.
+## Test matrix
 
-This is the first real smoke test of the v0 vertical slice shipped
-in PR #5. If anything breaks on this path, it's the first real bug
-since the auth-flow blocker.
+| Branch | Expected |
+|---|---|
+| valid `code`, stub returns session | 302 `/`, `Set-Cookie` HttpOnly+Secure+SameSite=Lax |
+| stub throws `token_used` | 302 `/auth?error=token_used`, no Set-Cookie |
+| stub throws `token_expired` | 302 `/auth?error=token_expired`, no Set-Cookie |
+| stub throws 5xx / network | 302 `/auth?error=server_error`, no Set-Cookie |
+| missing `code` param | 302 `/auth?error=invalid_request`, stub NOT called |
+| empty `code` | same as missing |
+| whitespace-only `code` | same as missing |
+| any failure branch | no `code` / `access_token` / `refresh_token` in `console.error` |
 
-## Open issues queued by this session
+## Non-negotiables (inherited)
 
-- **#18** — Framework persona (above; next session's #1).
-- **#19** — Five PR #17 council r4 nice-to-haves: client `AbortSignal`
-  timeout, null-byte email test, case-variant bucket test, multi-IP
-  XFF test, serial IP→email rate check.
-- **#20** — Playwright nonce smoke test. Would have prevented the
-  PR #17 dead-button bug if it had existed.
-- **#14** — CSP `report-uri` endpoint.
-- **#15** — `style-src` hardening (remove `'unsafe-inline'`).
-- **#12** — `/diag` removal + error-boundary production hardening.
-  Now that the full fix arc is green, `/diag` can be deleted.
-  Low-effort cleanup.
-- **#7** — `db-tests` pgTAP flake (still `continue-on-error`).
-- **#6** — Storage RLS metadata refactor (v0 deferral).
+- **No logging** of `code` or session tokens in any branch.
+- **Pin** `@supabase/ssr`; lockfile updated.
+- **Redirect URLs allowlist** locked to `APP_BASE_URL` pre-merge,
+  screenshot in PR body.
+- **Error surfacing** on `/auth` — no silent redirect.
+- **Council required** on this surface. No `[skip council]`.
+- **RLS unchanged.** Anon key only; no service-role exposure.
 
-## Non-goals for next session
+## Rollback
 
-- Feature work (v1 kickoff waits for confirmed end-to-end sign-in
-  + a PDF upload smoke test).
-- Merging any of the open issues above without their own plan +
-  council round.
-- Re-opening the CSP nonce design.
+Revert the PR. User returns to current state: email delivers, sign-in
+never completes. No additional regressions — this PR only touches the
+auth callback + its server-client factory; it does not migrate schema
+or change RLS.
 
-## Opening protocol (per CLAUDE.md)
+## Out of scope for this PR
 
-1. Read `.harness/session_state.json`.
-2. Read last ~20 lines of `.harness/yolo_log.jsonl`.
-3. Read the 2026-04-19 16:55 UTC block in `.harness/learnings.md`.
-4. Read this plan (§Next session's opener).
-5. Human will provide the end-to-end sign-in test result.
-6. If sign-in works → go to roadmap item #1 (framework persona).
-7. If sign-in fails → diagnose via Vercel Runtime Logs + `[magic-link]`
-   server-side error lines before spinning new council.
+- Framework specialist persona (#18) — queued as next priority after
+  this P0 lands.
+- Playwright nonce smoke test (#20).
+- `/diag` removal (#12), CSP `report-uri` (#14), `style-src`
+  hardening (#15).
+- Any v1 feature work.
+
+## Approval checklist (CLAUDE.md gate)
+
+Before writing implementation code, all three must be true:
+
+1. This file is committed on `claude/plan-session-agenda-rRwWN` and
+   pushed to origin.
+2. A PR is open against `main`; the latest `<!-- council-report -->`
+   comment from `.github/workflows/council.yml` was posted against a
+   commit SHA ≥ the commit that last modified this plan.
+3. The human has typed an explicit `approved` / `ship it` / `proceed`
+   after seeing (1) and (2).
+
+If any gate fails, stop and surface the gap.

--- a/.harness/active_plan.md
+++ b/.harness/active_plan.md
@@ -77,9 +77,11 @@ Pin `@supabase/ssr` in `packages/db/package.json`; regenerate
 
 `supabaseForRequest()` calls `createSupabaseClientForRequest` with the
 `next/headers` `cookies()` adapter. Wrap `setAll` in try/catch —
-Server Components can't set cookies (Next throws), so swallow that
-throw at the Server-Component call site; route handlers and server
-actions write normally.
+Server Components can't set cookies (Next throws), so the catch runs
+there; route handlers and server actions write normally. On catch,
+log at `debug` level with no cookie values (council bugs r1) so the
+swallow isn't silent and a future maintainer misusing the adapter in
+a Server Component can find it.
 
 ### D. Harden `apps/web/app/auth/callback/route.ts`
 
@@ -89,6 +91,9 @@ error shapes to kinds:
 - consumed code → `token_used`
 - expired code → `token_expired`
 - 5xx / network → `server_error`
+- 200 OK with `data.session: null` → `server_error` (council bugs r1)
+- any other thrown `Error` → `server_error` via a final catch-all so
+  the route can never return a 500 (council bugs r1)
 
 **Logging rules (non-negotiable):** never log `code`, `access_token`,
 or `refresh_token` under any branch. Log only the error kind + a
@@ -98,12 +103,22 @@ every failure branch.
 ### E. Surface the error on `/auth/page.tsx`
 
 Read `?error=` via `useSearchParams`; render an `aria-live="assertive"`
-message with kind-specific copy:
+message with kind-specific copy selected by an **allowlist** (switch /
+object map) on the parameter value. The raw query-param value is
+NEVER rendered into the DOM — any unknown kind falls through to a
+generic "Sign-in failed. Request a new link." message. This closes
+the XSS vector the security persona flagged at r1.
+
+Copy:
 
 - `token_used` → "This sign-in link has already been used. Request a new one."
 - `token_expired` → "This sign-in link has expired. Request a new one."
 - `server_error` → "Could not sign you in right now. Please try again."
 - `invalid_request` → "Sign-in link was invalid. Request a new one."
+- any other value → "Sign-in failed. Request a new link."
+
+Message text must meet **WCAG AA 4.5:1** contrast against its
+background (a11y r1).
 
 Form stays visible below the message so the user can request a fresh
 link without extra clicks.
@@ -130,16 +145,22 @@ the checklist for any future environment.
 
 | Branch | Expected |
 |---|---|
-| valid `code`, stub returns session | 302 `/`, `Set-Cookie` HttpOnly+Secure+SameSite=Lax |
+| valid `code`, stub returns session | 302 `/`, `Set-Cookie` HttpOnly+Secure+SameSite=Lax, `Path=/` |
 | stub throws `token_used` | 302 `/auth?error=token_used`, no Set-Cookie |
 | stub throws `token_expired` | 302 `/auth?error=token_expired`, no Set-Cookie |
 | stub throws 5xx / network | 302 `/auth?error=server_error`, no Set-Cookie |
+| stub returns 200 with `data.session: null` | 302 `/auth?error=server_error`, no Set-Cookie (council r1) |
+| stub throws generic `Error` | 302 `/auth?error=server_error`, no Set-Cookie, no 500 (council r1) |
 | missing `code` param | 302 `/auth?error=invalid_request`, stub NOT called |
 | empty `code` | same as missing |
 | whitespace-only `code` | same as missing |
-| any failure branch | no `code` / `access_token` / `refresh_token` in `console.error` |
+| `code` >4KB | 302 `/auth?error=invalid_request`, stub NOT called (council r1) |
+| `code` contains null byte / non-URL-safe chars | 302 `/auth?error=invalid_request`, stub NOT called (council r1) |
+| any failure branch | `console.error` spy sees no call whose args contain `code` / `access_token` / `refresh_token` (council r1) |
 
-## Non-negotiables (inherited)
+## Non-negotiables (inherited + council r1)
+
+Pre-existing (PR #21 handoff):
 
 - **No logging** of `code` or session tokens in any branch.
 - **Pin** `@supabase/ssr`; lockfile updated.
@@ -148,6 +169,22 @@ the checklist for any future environment.
 - **Error surfacing** on `/auth` — no silent redirect.
 - **Council required** on this surface. No `[skip council]`.
 - **RLS unchanged.** Anon key only; no service-role exposure.
+
+Added by council r1:
+
+- **[security]** Integration test MUST `vi.spyOn(console, 'error')`
+  and assert no call's arguments contain `code`, `access_token`, or
+  `refresh_token` substrings under any failure branch. Single most
+  important safeguard per the security persona.
+- **[security]** `/auth/page.tsx` error rendering MUST use an
+  allowlist (switch / object map) on the `error` query-param value.
+  The raw param value is never rendered; unknown kinds fall through
+  to a generic message. Closes the XSS vector.
+- **[security]** Supabase dashboard screenshots (Redirect URLs
+  allowlist AND both email templates on the PKCE redirect form) must
+  be in the implementation PR body before merge.
+- **[a11y]** Error message MUST meet WCAG AA 4.5:1 contrast against
+  background. Verify at implementation.
 
 ## Rollback
 
@@ -163,7 +200,30 @@ or change RLS.
 - Playwright nonce smoke test (#20).
 - `/diag` removal (#12), CSP `report-uri` (#14), `style-src`
   hardening (#15).
+- **i18n of the new error strings.** Hard-coded English copy is
+  acceptable for the P0 fix; externalization is a follow-up
+  (council a11y r1 noted this as a nice-to-have, not a blocker).
+- `pnpm audit` in CI. Council security r1 nice-to-have; separate
+  issue if we want it.
 - Any v1 feature work.
+
+## Success + kill criteria (council product r1)
+
+- **Success metric:** count of 302s from `/auth/callback` to `/` per
+  day (successful sign-ins). Track via existing server logs — no new
+  telemetry infra.
+- **Failure metric:** count of 302s from `/auth/callback` to
+  `/auth?error=<kind>` bucketed by kind.
+- **Kill criteria:** if total failure rate > 1% of sign-in attempts
+  24h after merge, revert the PR.
+- **Cost:** $0 marginal. Supabase Auth is MAU-billed, not per-call.
+
+## Council r1 synthesis
+
+Verdict **PROCEED** with the four additions above folded in. Scores
+a11y 8 / arch 10 / bugs 9 / cost 10 / product 10 / security 9. No
+non-negotiable violations. Full report:
+[PR #22 council comment](https://github.com/Anguijm/LLMwiki_StudyGroup/pull/22#issuecomment-4276576994).
 
 ## Approval checklist (CLAUDE.md gate)
 

--- a/.harness/active_plan.md
+++ b/.harness/active_plan.md
@@ -83,6 +83,11 @@ log at `debug` level with no cookie values (council bugs r1) so the
 swallow isn't silent and a future maintainer misusing the adapter in
 a Server Component can find it.
 
+Debug log message must explicitly state the expected cause (council
+security r2): `"supabase: setAll failed — expected in Server Component
+context, ignoring"`. Never include cookie values or names in the log
+line.
+
 ### D. Harden `apps/web/app/auth/callback/route.ts`
 
 Catch `exchangeCodeForSession` failures explicitly. Map known Supabase
@@ -92,8 +97,23 @@ error shapes to kinds:
 - expired code → `token_expired`
 - 5xx / network → `server_error`
 - 200 OK with `data.session: null` → `server_error` (council bugs r1)
+- 200 OK with unparseable JSON body → `server_error` via the final
+  catch-all (council bugs r2)
 - any other thrown `Error` → `server_error` via a final catch-all so
   the route can never return a 500 (council bugs r1)
+
+**Redirect rules (non-negotiable, council bugs r2):** the success
+redirect destination is **hardcoded to `/`**. No query parameter
+(including `redirect_to`, `next`, `returnTo`, or any other caller-
+supplied value) may influence the destination URL. This closes the
+open-redirect vector the bugs persona flagged.
+
+**Input validation (defense-in-depth, council security r2):** before
+invoking `exchangeCodeForSession`, validate the `code` param against a
+plausible charset (URL-safe base64 alphabet: `[A-Za-z0-9_\-]`) and
+length bound (reject `<16` or `>2048` chars). Fail to `invalid_request`.
+This is belt-and-suspenders; Supabase also validates, but a malformed
+code should never reach the network.
 
 **Logging rules (non-negotiable):** never log `code`, `access_token`,
 or `refresh_token` under any branch. Log only the error kind + a
@@ -156,6 +176,9 @@ the checklist for any future environment.
 | whitespace-only `code` | same as missing |
 | `code` >4KB | 302 `/auth?error=invalid_request`, stub NOT called (council r1) |
 | `code` contains null byte / non-URL-safe chars | 302 `/auth?error=invalid_request`, stub NOT called (council r1) |
+| `code` outside URL-safe base64 alphabet (e.g. `foo'bar"baz<qux>`) | 302 `/auth?error=invalid_request`, stub NOT called (council bugs r2) |
+| `code` valid + extraneous `redirect_to=https://evil.com` | 302 to `/` (hardcoded), NOT to the supplied URL (council bugs r2 — open-redirect guard) |
+| stub returns 200 with unparseable JSON body | 302 `/auth?error=server_error` via final catch-all (council bugs r2) |
 | any failure branch | `console.error` spy sees no call whose args contain `code` / `access_token` / `refresh_token` (council r1) |
 
 ## Non-negotiables (inherited + council r1)
@@ -186,6 +209,15 @@ Added by council r1:
 - **[a11y]** Error message MUST meet WCAG AA 4.5:1 contrast against
   background. Verify at implementation.
 
+Added by council r2:
+
+- **[bugs]** Success-redirect destination is **hardcoded to `/`**.
+  No caller-supplied query param (`redirect_to`, `next`, etc.) may
+  influence the target URL. Tested by the extraneous-param row in
+  the matrix above. Open-redirect guard.
+- **[bugs]** Unparseable JSON from `exchangeCodeForSession` maps to
+  `server_error` via the final catch-all; explicit test row required.
+
 ## Rollback
 
 Revert the PR. User returns to current state: email delivers, sign-in
@@ -205,6 +237,13 @@ or change RLS.
   (council a11y r1 noted this as a nice-to-have, not a blocker).
 - `pnpm audit` in CI. Council security r1 nice-to-have; separate
   issue if we want it.
+- **`Set-Cookie` header exceeding browser max size.** Council bugs
+  r2 flagged this as a theoretical failure mode (browser silently
+  drops oversize cookies). Cookie name and size are controlled by
+  `@supabase/ssr`, which splits large sessions into chunked cookies
+  under the 4KB-per-cookie browser limit. Not mitigable in our code.
+  If sessions routinely exceed limits, that's a Supabase-library
+  issue to escalate — out of scope for this P0.
 - Any v1 feature work.
 
 ## Success + kill criteria (council product r1)
@@ -218,12 +257,17 @@ or change RLS.
   24h after merge, revert the PR.
 - **Cost:** $0 marginal. Supabase Auth is MAU-billed, not per-call.
 
-## Council r1 synthesis
+## Council history
 
-Verdict **PROCEED** with the four additions above folded in. Scores
-a11y 8 / arch 10 / bugs 9 / cost 10 / product 10 / security 9. No
-non-negotiable violations. Full report:
-[PR #22 council comment](https://github.com/Anguijm/LLMwiki_StudyGroup/pull/22#issuecomment-4276576994).
+- **r1** (PR #22 @ commit `1ae040f`, 2026-04-19T18:48:54Z) — PROCEED,
+  a11y 8 / arch 10 / bugs 9 / cost 10 / product 10 / security 9. Four
+  new non-negotiables folded into this plan.
+- **r2** (PR #22 @ commit `ea3fc8a`, 2026-04-19T18:56:52Z) — PROCEED,
+  a11y **9** / arch 10 / bugs 9 / cost 10 / product 10 / security 9.
+  Five additions folded: open-redirect guard, unparseable-JSON test,
+  special-char code test, debug-log wording, defense-in-depth
+  charset/length validation on `code`. Full report:
+  [PR #22 council comment](https://github.com/Anguijm/LLMwiki_StudyGroup/pull/22#issuecomment-4276576994).
 
 ## Approval checklist (CLAUDE.md gate)
 

--- a/README.md
+++ b/README.md
@@ -245,11 +245,36 @@ deploy. Work through top-to-bottom once; subsequent deploys are just
 4. Dashboard → **Storage**: confirm the `ingest` bucket exists. It's created
    by migration `20260417000002_rls_policies.sql`. If missing, the migration
    failed — re-run `supabase db push` or check migration logs.
-5. Dashboard → **Authentication → URL Configuration**:
+5. Dashboard → **Authentication → URL Configuration** — **security
+   surface, verify with screenshots on every auth-touching PR (council
+   non-negotiable)**:
    - **Site URL** → your production URL (e.g. `https://<app>.vercel.app`).
-   - **Redirect URLs** → add both of:
+   - **Redirect URLs** → ONLY these two entries. No wildcards beyond the
+     preview-URL pattern. A misconfigured allowlist lets an attacker
+     redirect a valid PKCE code to a host they control:
      - `https://<app>.vercel.app/auth/callback`
      - `https://<app>-*.vercel.app/auth/callback` (Vercel preview deploys)
+   - Confirm this matches `APP_BASE_URL` in Vercel env vars (§C.3). The
+     server-side `/api/auth/magic-link` route already hard-requires
+     `APP_BASE_URL` and rejects Host-header spoofing; the Supabase
+     allowlist is the second line of defense.
+6. Dashboard → **Authentication → Email Templates** — **PKCE flow
+   requires explicit template edits; Supabase defaults ship the
+   implicit-flow URL form**:
+   - Open the **Confirm signup** template AND the **Magic Link**
+     template. Both must exist and both must be edited — users who
+     have never signed in hit the "Confirm signup" template, returning
+     users hit "Magic Link".
+   - In the confirmation link, the URL MUST be:
+     ```
+     {{ .SiteURL }}/auth/callback?code={{ .TokenHash }}
+     ```
+     The default templates use `#access_token=` (implicit flow); that
+     form bypasses our server-side `/auth/callback` handler and leaves
+     the session unpersisted. Verify by clicking **Preview** in each
+     template and confirming the URL includes `/auth/callback?code=`.
+   - Screenshot both templates plus the URL Configuration section and
+     attach to the auth-surface PR before merge.
 
 ### C. Vercel: project + settings + env vars
 

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -5,13 +5,21 @@
 // the @supabase/ssr setAll adapter in apps/web/lib/supabase.ts) and
 // redirects to the dashboard.
 //
-// Security posture (plan PR #22, council rounds r1 / r2 / r3):
+// Security posture (plan PR #22, council rounds r1 / r2 / r3 / r4):
 //
-//   - Input validation runs BEFORE any Supabase call. Missing / empty /
-//     whitespace / too-short / too-long / non-URL-safe `code` values
-//     redirect to /auth?error=invalid_request immediately. Defense in
-//     depth: Supabase also validates, but a malformed code should never
-//     touch the network.
+//   - Per-IP rate limit (20 req / min, fail-open on Upstash outage).
+//     /auth/callback is a public endpoint that fans out to Supabase
+//     Auth; without a limiter an attacker can spam bad codes and
+//     consume our server + Supabase's per-project rate budget (council
+//     security r4 blocker: non-negotiable on public endpoints with
+//     external API fan-out). Fail-open intentional: a Redis outage
+//     must not 503 a legit magic-link click.
+//
+//   - Input validation runs BEFORE the Supabase call. Missing /
+//     empty / whitespace / too-short / too-long / non-URL-safe `code`
+//     values redirect to /auth?error=invalid_request immediately.
+//     Defense in depth: Supabase also validates, but a malformed code
+//     should never touch the network.
 //
 //   - Every failure branch — Supabase-shaped errors, a 200 OK with
 //     `data.session: null`, unparseable JSON responses, and generic
@@ -35,6 +43,10 @@
 
 import { NextResponse, type NextRequest } from 'next/server';
 import { supabaseForRequest } from '../../../lib/supabase';
+import {
+  makeAuthCallbackLimiter,
+  RateLimitExceededError,
+} from '@llmwiki/lib-ratelimit';
 
 export const runtime = 'nodejs';
 
@@ -58,12 +70,29 @@ function validateCode(raw: string | null): ErrorKind | null {
 }
 
 /**
+ * Extract a rate-limit bucket key from the request. Vercel guarantees
+ * X-Forwarded-For on production traffic. If the header is absent (local
+ * dev, odd proxy chains), fall back to a shared "unknown" bucket — the
+ * shared bucket means worst-case all IP-less traffic shares a 20/min
+ * ceiling, which is annoying but not a user-denial.
+ */
+function rateLimitBucket(req: NextRequest): string {
+  const xff = req.headers.get('x-forwarded-for');
+  const first = xff?.split(',')[0]?.trim();
+  if (first && first.length > 0) return first;
+  const xri = req.headers.get('x-real-ip')?.trim();
+  if (xri && xri.length > 0) return xri;
+  return 'no-xff';
+}
+
+/**
  * Map a Supabase auth error to one of our user-facing kinds. Supabase
  * doesn't expose stable error codes for PKCE exchange failures, so we
  * match on message substrings with explicit fall-through to
  * `server_error`. If Supabase changes its error copy in a future
  * release, the result is more "server_error" toasts rather than a
- * crash — acceptable graceful degradation.
+ * crash — acceptable graceful degradation (council security r4
+ * nice-to-have: revisit if Supabase ever exposes stable codes).
  */
 function mapSupabaseError(err: { message?: string; status?: number } | null): ErrorKind {
   if (!err) return 'server_error';
@@ -82,16 +111,48 @@ function redirectToAuthError(req: NextRequest, kind: ErrorKind): NextResponse {
   return NextResponse.redirect(target);
 }
 
-export async function GET(req: NextRequest): Promise<NextResponse> {
-  const code = new URL(req.url).searchParams.get('code');
+function tooManyRequests(resetsAt: Date): NextResponse {
+  const retryAfterSec = Math.max(
+    1,
+    Math.ceil((resetsAt.getTime() - Date.now()) / 1000),
+  );
+  return new NextResponse('Too many requests. Please try again in a moment.', {
+    status: 429,
+    headers: {
+      'retry-after': String(retryAfterSec),
+      'content-type': 'text/plain; charset=utf-8',
+    },
+  });
+}
 
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  // 1. Rate limit FIRST. Validation is cheap but unbounded requests to a
+  // public endpoint still cost cycles, and a future refactor that moves
+  // validation later should never drop the rate-limit gate.
+  try {
+    await makeAuthCallbackLimiter().reserve(rateLimitBucket(req));
+  } catch (err) {
+    if (err instanceof RateLimitExceededError) {
+      return tooManyRequests(err.resetsAt);
+    }
+    // Limiter's reserve() only throws RateLimitExceededError (it
+    // fail-opens on Upstash outage). Any other throw is unexpected —
+    // let it propagate so the platform's error reporting picks it up;
+    // the route's final catch-all below won't run here because this
+    // block is outside the exchange try/catch by design (rate-limit
+    // failures are infrastructure errors, not sign-in errors).
+    throw err;
+  }
+
+  // 2. Input validation.
+  const code = new URL(req.url).searchParams.get('code');
   const validation = validateCode(code);
   if (validation !== null) {
     return redirectToAuthError(req, validation);
   }
-  // After validation, `code` is guaranteed non-null and trimmed shape.
   const trimmedCode = (code as string).trim();
 
+  // 3. Exchange the code, mapping every failure shape to a known kind.
   let failureKind: ErrorKind | null = null;
   try {
     const supabase = await supabaseForRequest();

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -1,20 +1,128 @@
-// Supabase Auth code-exchange landing URL. The magic-link email points at
-// /auth/callback?code=...; we exchange the code for a session cookie and
-// redirect to the dashboard.
+// GET /auth/callback — Supabase PKCE auth code-exchange landing URL.
+//
+// The magic-link email points the user at /auth/callback?code=...; this
+// route exchanges the short-lived code for a session cookie (written via
+// the @supabase/ssr setAll adapter in apps/web/lib/supabase.ts) and
+// redirects to the dashboard.
+//
+// Security posture (plan PR #22, council rounds r1 / r2 / r3):
+//
+//   - Input validation runs BEFORE any Supabase call. Missing / empty /
+//     whitespace / too-short / too-long / non-URL-safe `code` values
+//     redirect to /auth?error=invalid_request immediately. Defense in
+//     depth: Supabase also validates, but a malformed code should never
+//     touch the network.
+//
+//   - Every failure branch — Supabase-shaped errors, a 200 OK with
+//     `data.session: null`, unparseable JSON responses, and generic
+//     thrown Errors — maps to a known error kind and 307s to
+//     /auth?error=<kind>. The final catch-all guarantees this route
+//     never returns a 500 (council bugs r1 / r2 / r3).
+//
+//   - The success redirect is HARDCODED to `/`. No caller-supplied
+//     query parameter (`redirect_to`, `next`, etc.) may influence the
+//     destination URL. Forwarding an attacker-controlled URL here
+//     would be an open-redirect vector (council bugs r2). If a
+//     post-sign-in destination is ever needed, store it server-side
+//     (e.g., a cookie set at magic-link send time) — never in the
+//     callback query string.
+//
+//   - Logs NEVER contain the `code`, `access_token`, or `refresh_token`
+//     values. Only the mapped error kind and (optionally) the thrown
+//     error's class name are emitted. The integration test suite at
+//     apps/web/tests/unit/auth-callback-route.test.ts spies on
+//     console.error and fails if any of those substrings appear.
+
 import { NextResponse, type NextRequest } from 'next/server';
 import { supabaseForRequest } from '../../../lib/supabase';
 
-export async function GET(req: NextRequest) {
-  const code = new URL(req.url).searchParams.get('code');
-  if (!code) return NextResponse.redirect(new URL('/auth', req.url));
+export const runtime = 'nodejs';
 
-  const supabase = await supabaseForRequest();
-  const { error } = await supabase.auth.exchangeCodeForSession(code);
-  if (error) {
-    const url = new URL('/auth', req.url);
-    url.searchParams.set('error', error.message);
-    return NextResponse.redirect(url);
+type ErrorKind = 'invalid_request' | 'token_expired' | 'token_used' | 'server_error';
+
+// URL-safe base64 alphabet. Supabase PKCE codes are opaque strings within
+// this character set; anything else is an obvious probe / garbage and is
+// rejected before consuming a round trip.
+const VALID_CODE_RE = /^[A-Za-z0-9_-]+$/;
+const MIN_CODE_LEN = 16;
+const MAX_CODE_LEN = 2048;
+
+function validateCode(raw: string | null): ErrorKind | null {
+  if (raw === null) return 'invalid_request';
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return 'invalid_request';
+  if (trimmed.length < MIN_CODE_LEN) return 'invalid_request';
+  if (trimmed.length > MAX_CODE_LEN) return 'invalid_request';
+  if (!VALID_CODE_RE.test(trimmed)) return 'invalid_request';
+  return null;
+}
+
+/**
+ * Map a Supabase auth error to one of our user-facing kinds. Supabase
+ * doesn't expose stable error codes for PKCE exchange failures, so we
+ * match on message substrings with explicit fall-through to
+ * `server_error`. If Supabase changes its error copy in a future
+ * release, the result is more "server_error" toasts rather than a
+ * crash — acceptable graceful degradation.
+ */
+function mapSupabaseError(err: { message?: string; status?: number } | null): ErrorKind {
+  if (!err) return 'server_error';
+  if (typeof err.status === 'number' && err.status >= 500) return 'server_error';
+  const msg = (err.message ?? '').toLowerCase();
+  if (/\balready\b.*\bused\b|consumed|used_otp|invalid_grant/.test(msg)) {
+    return 'token_used';
+  }
+  if (/expired|otp_expired/.test(msg)) return 'token_expired';
+  return 'server_error';
+}
+
+function redirectToAuthError(req: NextRequest, kind: ErrorKind): NextResponse {
+  const target = new URL('/auth', req.url);
+  target.searchParams.set('error', kind);
+  return NextResponse.redirect(target);
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const code = new URL(req.url).searchParams.get('code');
+
+  const validation = validateCode(code);
+  if (validation !== null) {
+    return redirectToAuthError(req, validation);
+  }
+  // After validation, `code` is guaranteed non-null and trimmed shape.
+  const trimmedCode = (code as string).trim();
+
+  let failureKind: ErrorKind | null = null;
+  try {
+    const supabase = await supabaseForRequest();
+    const { data, error } = await supabase.auth.exchangeCodeForSession(trimmedCode);
+    if (error) {
+      failureKind = mapSupabaseError(error);
+    } else if (!data?.session) {
+      // Unexpected: 200 OK with no session body. Treat as a server error
+      // rather than let a downstream null deref leak through (council
+      // bugs r1).
+      failureKind = 'server_error';
+    }
+  } catch (err) {
+    // Final catch-all. A JSON parse failure, TypeError, network drop,
+    // or any non-Error throw lands here and is mapped to server_error.
+    // The route MUST NOT return a 500 (council bugs r1 / r2 / r3).
+    // We log only the error's class name — never the message (which
+    // might echo the code), never the object (which might carry
+    // access/refresh tokens from a partial Supabase response).
+    console.error('[auth/callback] unexpected exchange failure', {
+      kind: 'server_error',
+      errorName: err instanceof Error ? err.name : typeof err,
+    });
+    failureKind = 'server_error';
   }
 
+  if (failureKind !== null) {
+    console.error('[auth/callback] sign-in failed', { kind: failureKind });
+    return redirectToAuthError(req, failureKind);
+  }
+
+  // SECURITY: destination is hardcoded. See file header comment.
   return NextResponse.redirect(new URL('/', req.url));
 }

--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -4,9 +4,47 @@
 // /api/auth/magic-link; this form POSTs to that route so rate-limiting
 // runs on the server and the email channel can't be flooded by a looping
 // client. OAuth is a v1 addition with its own plan + council round.
-import { useState } from 'react';
+//
+// Two error surfaces live on this page:
+//
+//   1. Form-submit errors (state: `err`) from the client fetch to
+//      /api/auth/magic-link. Existing since PR #17.
+//
+//   2. Sign-in-callback errors (derived from the `?error=<kind>` query
+//      param set by /auth/callback when exchangeCodeForSession fails).
+//      Added in PR #22. XSS-safe by design: the raw query-param value
+//      is NEVER rendered; the value is used only as an allowlist key
+//      into CALLBACK_ERROR_MESSAGES. Unknown kinds fall through to a
+//      generic string (council security r1).
+import { Suspense, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 
-export default function AuthPage() {
+/**
+ * Allowlist of callback-error kinds → user-facing copy. Adding a new
+ * kind: update /auth/callback/route.ts's ErrorKind union and add an
+ * entry here. Unknown values (old bookmarked URLs, attacker probes,
+ * encoded script tags, etc.) render the generic fallback — their raw
+ * bytes never reach the DOM.
+ */
+const CALLBACK_ERROR_MESSAGES: Readonly<Record<string, string>> = {
+  token_used: 'This sign-in link has already been used. Request a new one.',
+  token_expired: 'This sign-in link has expired. Request a new one.',
+  server_error: 'Could not sign you in right now. Please try again.',
+  invalid_request: 'Sign-in link was invalid. Request a new one.',
+};
+const GENERIC_CALLBACK_ERROR = 'Sign-in failed. Request a new link.';
+
+function resolveCallbackError(raw: string | null): string | null {
+  if (!raw) return null;
+  // Allowlist lookup ONLY. The raw param is never interpolated into
+  // markup — prevents reflected XSS via /auth?error=<script>...</script>.
+  return CALLBACK_ERROR_MESSAGES[raw] ?? GENERIC_CALLBACK_ERROR;
+}
+
+function AuthForm() {
+  const searchParams = useSearchParams();
+  const callbackError = resolveCallbackError(searchParams.get('error'));
+
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -67,33 +105,61 @@ export default function AuthPage() {
   }
 
   return (
-    <form onSubmit={onSubmit} className="max-w-sm">
-      <label htmlFor="email" className="block text-sm font-medium text-brand-900">
-        Email
-      </label>
-      <input
-        id="email"
-        type="email"
-        required
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        aria-describedby={err ? 'auth-error' : undefined}
-        disabled={pending}
-        className="mt-1 block w-full border border-brand-100 rounded-md px-3 py-2 min-h-[44px] disabled:bg-brand-50 disabled:text-brand-700 disabled:cursor-not-allowed"
-      />
-      {err && (
-        <p id="auth-error" role="alert" aria-live="assertive" className="mt-2 text-danger text-sm">
-          {err}
+    <div className="max-w-sm">
+      {callbackError && (
+        <p
+          id="callback-error"
+          role="alert"
+          aria-live="assertive"
+          className="mb-4 text-danger text-sm font-medium"
+        >
+          {callbackError}
         </p>
       )}
-      <button
-        type="submit"
-        disabled={pending}
-        aria-busy={pending}
-        className="mt-4 bg-brand-900 text-white px-4 py-2 rounded-md min-h-[44px] disabled:bg-brand-700 disabled:cursor-not-allowed"
-      >
-        {pending ? 'Sending…' : 'Send magic link'}
-      </button>
-    </form>
+      <form onSubmit={onSubmit}>
+        <label htmlFor="email" className="block text-sm font-medium text-brand-900">
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          aria-describedby={
+            err
+              ? 'auth-error'
+              : callbackError
+                ? 'callback-error'
+                : undefined
+          }
+          disabled={pending}
+          className="mt-1 block w-full border border-brand-100 rounded-md px-3 py-2 min-h-[44px] disabled:bg-brand-50 disabled:text-brand-700 disabled:cursor-not-allowed"
+        />
+        {err && (
+          <p id="auth-error" role="alert" aria-live="assertive" className="mt-2 text-danger text-sm">
+            {err}
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={pending}
+          aria-busy={pending}
+          className="mt-4 bg-brand-900 text-white px-4 py-2 rounded-md min-h-[44px] disabled:bg-brand-700 disabled:cursor-not-allowed"
+        >
+          {pending ? 'Sending…' : 'Send magic link'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default function AuthPage() {
+  // useSearchParams triggers CSR bailout in Next.js 15 and needs a
+  // Suspense boundary above it to keep the rest of the tree static-eligible.
+  return (
+    <Suspense fallback={null}>
+      <AuthForm />
+    </Suspense>
   );
 }

--- a/apps/web/lib/supabase.test.ts
+++ b/apps/web/lib/supabase.test.ts
@@ -1,0 +1,132 @@
+// Unit coverage for the Next.js cookies() adapter wired into
+// createSupabaseClientForRequest in ./supabase.ts.
+//
+// Council r4 bugs concern: the previous draft swallowed every setAll
+// throw behind `if (process.env.NODE_ENV !== 'production')`, which
+// meant a genuine Route-Handler failure in prod left no trace. The
+// current adapter discriminates on the error message: a Next.js
+// "cookies can only be modified in a Server Action or Route Handler"
+// throw is EXPECTED when a Server Component reads session state and is
+// swallowed silently; anything else is logged via console.error (with
+// cookie names/values omitted) so the bug is visible in production.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type CookieAdapter = {
+  getAll: () => Array<{ name: string; value: string }>;
+  setAll: (
+    cookies: Array<{ name: string; value: string; options?: unknown }>,
+  ) => void;
+};
+
+// Stub next/headers. The test controls what cookies().set() throws.
+const setStub = vi.fn();
+const cookiesStub = {
+  getAll: () => [] as Array<{ name: string; value: string }>,
+  set: (name: string, value: string, options?: unknown) =>
+    setStub(name, value, options),
+};
+vi.mock('next/headers', () => ({
+  cookies: async () => cookiesStub,
+}));
+
+// Capture the adapter passed into createSupabaseClientForRequest so the
+// test can drive the setAll path directly. The returned "client" object
+// is a no-op stub; none of its methods are exercised.
+const capturedAdapter: { current: CookieAdapter | null } = { current: null };
+
+vi.mock('@llmwiki/db/server', () => ({
+  createSupabaseClientForRequest: (cookies: CookieAdapter) => {
+    capturedAdapter.current = cookies;
+    return {};
+  },
+  createSupabaseClientForJobs: () => ({}),
+  supabaseService: () => ({}),
+}));
+
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.resetModules();
+  setStub.mockReset();
+  capturedAdapter.current = null;
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  errSpy.mockRestore();
+});
+
+describe('supabaseForRequest — setAll cookie-write discriminator', () => {
+  it('swallows the Next.js RSC read-only error silently (no log)', async () => {
+    setStub.mockImplementation(() => {
+      throw new Error(
+        'Cookies can only be modified in a Server Action or Route Handler. ' +
+          'Read more: https://nextjs.org/docs/...',
+      );
+    });
+    const { supabaseForRequest } = await import('./supabase');
+    await supabaseForRequest();
+    expect(capturedAdapter.current).not.toBeNull();
+    // Drive the adapter directly.
+    capturedAdapter.current!.setAll([
+      { name: 'sb-access-token', value: 'SECRET', options: {} },
+    ]);
+    // Expected RSC context → silent swallow. Nothing in console.error.
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs console.error on an unexpected setAll throw (Route Handler bug)', async () => {
+    setStub.mockImplementation(() => {
+      throw new Error('ECONNRESET — upstream write failed');
+    });
+    const { supabaseForRequest } = await import('./supabase');
+    await supabaseForRequest();
+    capturedAdapter.current!.setAll([
+      { name: 'sb-access-token', value: 'SECRET', options: {} },
+    ]);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    const [message, context] = errSpy.mock.calls[0] as [string, unknown];
+    expect(message).toMatch(/setAll failed/i);
+    // Regression guard: cookie name + value must NOT appear in the log.
+    const contextString = JSON.stringify(context);
+    expect(message).not.toContain('sb-access-token');
+    expect(message).not.toContain('SECRET');
+    expect(contextString).not.toContain('sb-access-token');
+    expect(contextString).not.toContain('SECRET');
+  });
+
+  it('continues processing the remaining cookies after one throws', async () => {
+    // The setAll loop must not halt on a single throw — otherwise a
+    // partial write leaves the client in an inconsistent state.
+    const attempted: string[] = [];
+    setStub.mockImplementation((name: string) => {
+      attempted.push(name);
+      if (name === 'second')
+        throw new Error(
+          'Cookies can only be modified in a Server Action or Route Handler',
+        );
+    });
+    const { supabaseForRequest } = await import('./supabase');
+    await supabaseForRequest();
+    capturedAdapter.current!.setAll([
+      { name: 'first', value: 'a', options: {} },
+      { name: 'second', value: 'b', options: {} },
+      { name: 'third', value: 'c', options: {} },
+    ]);
+    expect(attempted).toEqual(['first', 'second', 'third']);
+  });
+
+  it('treats a non-Error throw as unexpected and logs it', async () => {
+    setStub.mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- test-only
+      throw 'bare string rejection';
+    });
+    const { supabaseForRequest } = await import('./supabase');
+    await supabaseForRequest();
+    capturedAdapter.current!.setAll([
+      { name: 'x', value: 'y', options: {} },
+    ]);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/supabase.test.ts
+++ b/apps/web/lib/supabase.test.ts
@@ -76,7 +76,7 @@ describe('supabaseForRequest — setAll cookie-write discriminator', () => {
     expect(errSpy).not.toHaveBeenCalled();
   });
 
-  it('logs console.error on an unexpected setAll throw (Route Handler bug)', async () => {
+  it('logs a partial-write summary on an unexpected setAll throw (Route Handler bug)', async () => {
     setStub.mockImplementation(() => {
       throw new Error('ECONNRESET — upstream write failed');
     });
@@ -87,7 +87,8 @@ describe('supabaseForRequest — setAll cookie-write discriminator', () => {
     ]);
     expect(errSpy).toHaveBeenCalledTimes(1);
     const [message, context] = errSpy.mock.calls[0] as [string, unknown];
-    expect(message).toMatch(/setAll failed/i);
+    expect(message).toMatch(/setAll partial write/i);
+    expect(message).toMatch(/1\/1/);
     // Regression guard: cookie name + value must NOT appear in the log.
     const contextString = JSON.stringify(context);
     expect(message).not.toContain('sb-access-token');
@@ -96,9 +97,36 @@ describe('supabaseForRequest — setAll cookie-write discriminator', () => {
     expect(contextString).not.toContain('SECRET');
   });
 
+  it('reports N/M when some writes succeed and some fail (council bugs r5)', async () => {
+    // @supabase/ssr typically sends multiple chunked cookies; a partial
+    // write (1 of 3 fails) must surface as "1/3 cookie writes failed"
+    // so the debugger sees the split state at a glance.
+    setStub.mockImplementation((name: string) => {
+      if (name === 'sb-access-token.1') {
+        throw new Error('ECONNRESET — upstream write failed');
+      }
+    });
+    const { supabaseForRequest } = await import('./supabase');
+    await supabaseForRequest();
+    capturedAdapter.current!.setAll([
+      { name: 'sb-access-token.0', value: 'part0', options: {} },
+      { name: 'sb-access-token.1', value: 'part1', options: {} },
+      { name: 'sb-access-token.2', value: 'part2', options: {} },
+    ]);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    const [message] = errSpy.mock.calls[0] as [string, unknown];
+    expect(message).toMatch(/1\/3/);
+    expect(message).toMatch(/partial write/i);
+    // Cookie identifiers and values must not appear in the summary.
+    expect(message).not.toContain('sb-access-token');
+    expect(message).not.toContain('part0');
+    expect(message).not.toContain('part1');
+    expect(message).not.toContain('part2');
+  });
+
   it('continues processing the remaining cookies after one throws', async () => {
-    // The setAll loop must not halt on a single throw — otherwise a
-    // partial write leaves the client in an inconsistent state.
+    // Regression: the loop must not halt on a single throw — otherwise
+    // a single flaky cookie would skip the rest of the session chunks.
     const attempted: string[] = [];
     setStub.mockImplementation((name: string) => {
       attempted.push(name);
@@ -115,6 +143,24 @@ describe('supabaseForRequest — setAll cookie-write discriminator', () => {
       { name: 'third', value: 'c', options: {} },
     ]);
     expect(attempted).toEqual(['first', 'second', 'third']);
+  });
+
+  it('emits no summary log when all throws are the expected RSC case', async () => {
+    // An all-RSC-expected pass should stay silent — the previous
+    // iteration inadvertently logged once per cookie, which would be
+    // noisy in every Server Component render.
+    setStub.mockImplementation(() => {
+      throw new Error(
+        'Cookies can only be modified in a Server Action or Route Handler',
+      );
+    });
+    const { supabaseForRequest } = await import('./supabase');
+    await supabaseForRequest();
+    capturedAdapter.current!.setAll([
+      { name: 'a', value: '1', options: {} },
+      { name: 'b', value: '2', options: {} },
+    ]);
+    expect(errSpy).not.toHaveBeenCalled();
   });
 
   it('treats a non-Error throw as unexpected and logs it', async () => {

--- a/apps/web/lib/supabase.ts
+++ b/apps/web/lib/supabase.ts
@@ -33,23 +33,30 @@ export async function supabaseForRequest() {
       for (const { name, value, options } of cookiesToSet) {
         try {
           store.set(name, value, options);
-        } catch {
-          // Cookie mutation is only supported in Route Handlers and
-          // Server Actions. When this client is used from a Server
-          // Component render, Next.js throws here — that case is
-          // EXPECTED and correct (an RSC should not be rewriting the
-          // user's session cookie). Drop the write so the read path
-          // still returns fresh user data. Any other failure mode
-          // (e.g. a Route Handler where writes should work) will
-          // surface in dev via this log without exposing the cookie.
-          if (process.env.NODE_ENV !== 'production') {
-            // eslint-disable-next-line no-console
-            console.debug(
-              'supabase: setAll failed in a context where cookie writing ' +
-                'is not supported (e.g., Server Component). This is expected ' +
-                'when reading session state from an RSC; ignoring.',
-            );
-          }
+        } catch (err) {
+          // Discriminate two failure modes (council bugs r4):
+          //
+          //   1. Server Component context — Next.js forbids cookie
+          //      mutation from render. The thrown error's message
+          //      contains "Cookies can only be modified in a Server
+          //      Action or Route Handler" (or minor variants across
+          //      Next versions). This is EXPECTED when an RSC reads
+          //      session state via this client; swallow silently.
+          //
+          //   2. Anything else — a Route Handler or Server Action
+          //      where the write SHOULD have succeeded but didn't.
+          //      That's a bug we need to surface in production too;
+          //      log at error level with no cookie values.
+          const msg = err instanceof Error ? err.message : String(err);
+          const isExpectedRscContext =
+            /cookies.*modif|server\s*action|route\s*handler/i.test(msg);
+          if (isExpectedRscContext) continue;
+          // eslint-disable-next-line no-console
+          console.error(
+            'supabase: setAll failed in a write-capable context. ' +
+              'Investigate — cookie name and value omitted to avoid leakage.',
+            { errorName: err instanceof Error ? err.name : typeof err },
+          );
         }
       }
     },

--- a/apps/web/lib/supabase.ts
+++ b/apps/web/lib/supabase.ts
@@ -30,34 +30,47 @@ export async function supabaseForRequest() {
       return store.getAll().map(({ name, value }) => ({ name, value }));
     },
     setAll(cookiesToSet) {
+      // Discriminate two failure modes per write (council bugs r4) AND
+      // accumulate unexpected failures so we can surface one partial-
+      // write summary at the end (council bugs r5).
+      //
+      //   1. Server Component context — Next.js forbids cookie mutation
+      //      from render. The thrown error's message contains "Cookies
+      //      can only be modified in a Server Action or Route Handler"
+      //      (or minor variants across Next versions). Expected when an
+      //      RSC reads session state via this client; swallow silently.
+      //
+      //   2. Anything else — a Route Handler or Server Action where the
+      //      write SHOULD have succeeded but didn't. @supabase/ssr
+      //      typically sends multiple chunked cookies in one setAll
+      //      call; if one fails but others succeed the user is left
+      //      with a partial session. Continuing the loop is right
+      //      (best-effort: maybe one chunk was transient), but a
+      //      post-loop summary log makes the partial-write signal
+      //      explicit so a future debug session doesn't miss it.
+      const unexpectedErrorNames: string[] = [];
       for (const { name, value, options } of cookiesToSet) {
         try {
           store.set(name, value, options);
         } catch (err) {
-          // Discriminate two failure modes (council bugs r4):
-          //
-          //   1. Server Component context — Next.js forbids cookie
-          //      mutation from render. The thrown error's message
-          //      contains "Cookies can only be modified in a Server
-          //      Action or Route Handler" (or minor variants across
-          //      Next versions). This is EXPECTED when an RSC reads
-          //      session state via this client; swallow silently.
-          //
-          //   2. Anything else — a Route Handler or Server Action
-          //      where the write SHOULD have succeeded but didn't.
-          //      That's a bug we need to surface in production too;
-          //      log at error level with no cookie values.
           const msg = err instanceof Error ? err.message : String(err);
           const isExpectedRscContext =
             /cookies.*modif|server\s*action|route\s*handler/i.test(msg);
           if (isExpectedRscContext) continue;
-          // eslint-disable-next-line no-console
-          console.error(
-            'supabase: setAll failed in a write-capable context. ' +
-              'Investigate — cookie name and value omitted to avoid leakage.',
-            { errorName: err instanceof Error ? err.name : typeof err },
+          unexpectedErrorNames.push(
+            err instanceof Error ? err.name : typeof err,
           );
         }
+      }
+      if (unexpectedErrorNames.length > 0) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `supabase: setAll partial write — ${unexpectedErrorNames.length}/` +
+            `${cookiesToSet.length} cookie writes failed in a write-capable ` +
+            'context. Session may be inconsistent. Cookie names and values ' +
+            'omitted to avoid leakage.',
+          { errorNames: unexpectedErrorNames },
+        );
       }
     },
   });

--- a/apps/web/lib/supabase.ts
+++ b/apps/web/lib/supabase.ts
@@ -3,15 +3,63 @@
 // package is usable from Inngest and future non-Next callers.
 import 'server-only';
 import { cookies } from 'next/headers';
-import { supabaseServer, supabaseService } from '@llmwiki/db/server';
+import {
+  createSupabaseClientForRequest,
+  createSupabaseClientForJobs,
+  supabaseService,
+} from '@llmwiki/db/server';
 
 /**
- * Server-component / server-action Supabase client scoped to the current
- * request's session cookie. Observes RLS via auth.uid().
+ * Request-scoped Supabase client wired to Next.js's `cookies()` API.
+ * Reads AND writes cookies — so this is the correct factory for Route
+ * Handlers, Server Actions, AND Server Components (reads only).
+ *
+ * For PKCE sign-in: /auth/callback hits exchangeCodeForSession, which
+ * writes the session cookie via the setAll callback below. Before PR
+ * #22 this path used a read-only client and the session landed on the
+ * floor. See packages/db/src/server.ts for the factory split rationale.
+ *
+ * In a Server Component, Next.js forbids cookie mutation — `store.set`
+ * throws. That's expected when a component reads session state via this
+ * client, so we catch the throw and debug-log rather than propagate.
  */
 export async function supabaseForRequest() {
   const store = await cookies();
-  return supabaseServer(store.toString());
+  return createSupabaseClientForRequest({
+    getAll() {
+      return store.getAll().map(({ name, value }) => ({ name, value }));
+    },
+    setAll(cookiesToSet) {
+      for (const { name, value, options } of cookiesToSet) {
+        try {
+          store.set(name, value, options);
+        } catch {
+          // Cookie mutation is only supported in Route Handlers and
+          // Server Actions. When this client is used from a Server
+          // Component render, Next.js throws here — that case is
+          // EXPECTED and correct (an RSC should not be rewriting the
+          // user's session cookie). Drop the write so the read path
+          // still returns fresh user data. Any other failure mode
+          // (e.g. a Route Handler where writes should work) will
+          // surface in dev via this log without exposing the cookie.
+          if (process.env.NODE_ENV !== 'production') {
+            // eslint-disable-next-line no-console
+            console.debug(
+              'supabase: setAll failed in a context where cookie writing ' +
+                'is not supported (e.g., Server Component). This is expected ' +
+                'when reading session state from an RSC; ignoring.',
+            );
+          }
+        }
+      }
+    },
+  });
 }
 
-export { supabaseService };
+/**
+ * Read-only Supabase client for cookie-less server contexts. Prefer
+ * supabaseForRequest above; this factory is exposed for Inngest-style
+ * workers that receive a raw Cookie header string and have no response
+ * to carry Set-Cookie.
+ */
+export { supabaseService, createSupabaseClientForJobs };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "@llmwiki/lib-ai": "workspace:*",
     "@llmwiki/lib-metrics": "workspace:*",
     "@llmwiki/lib-ratelimit": "workspace:*",
-    "@supabase/ssr": "^0.4.0",
+    "@supabase/ssr": "0.4.1",
     "@supabase/supabase-js": "^2.45.0",
     "inngest": "^3.22.0",
     "next": "^15.0.0",

--- a/apps/web/tests/unit/auth-callback-route.test.ts
+++ b/apps/web/tests/unit/auth-callback-route.test.ts
@@ -37,6 +37,21 @@ vi.mock('../../lib/supabase', () => ({
   }),
 }));
 
+// Rate-limiter mock. The real @llmwiki/lib-ratelimit requires an Upstash
+// env + network; swap it for a per-test spy so we can exercise both the
+// allow-through and 429 branches without touching Redis. We re-export
+// the real RateLimitExceededError class so the route's `instanceof`
+// check still matches.
+const reserveSpy = vi.fn(async () => undefined);
+
+vi.mock('@llmwiki/lib-ratelimit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@llmwiki/lib-ratelimit')>();
+  return {
+    ...actual,
+    makeAuthCallbackLimiter: () => ({ reserve: reserveSpy }),
+  };
+});
+
 /** URL-safe base64 code of plausible length (32 chars). */
 const VALID_CODE = 'abcdefghijklmnopqrstuvwxyz012345';
 
@@ -75,6 +90,8 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   exchangeCodeForSession.mockReset();
+  reserveSpy.mockReset();
+  reserveSpy.mockResolvedValue(undefined); // default: allow through
   errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 });
 
@@ -328,6 +345,71 @@ describe('GET /auth/callback — Supabase error branches', () => {
     expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
       'server_error',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate limiting: per-IP 20/min. Over-limit returns 429 with Retry-After.
+// Upstash outage is fail-open (handled inside the limiter itself; tested
+// separately in the ratelimit package's unit suite).
+// ---------------------------------------------------------------------------
+describe('GET /auth/callback — rate limiting (council r4 blocker)', () => {
+  it('returns 429 with Retry-After when the limiter rejects', async () => {
+    const { RateLimitExceededError } = await import('@llmwiki/lib-ratelimit');
+    const resetsAt = new Date(Date.now() + 30_000);
+    reserveSpy.mockRejectedValueOnce(
+      new RateLimitExceededError('auth_callback_ip', resetsAt),
+    );
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(res.status).toBe(429);
+    expect(Number(res.headers.get('retry-after'))).toBeGreaterThan(0);
+    expect(Number(res.headers.get('retry-after'))).toBeLessThanOrEqual(31);
+    // The 429 short-circuits before the Supabase call.
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+    // No tokens in logs (even though we never got to a code branch).
+    assertNoTokenLeaks(errorSpy, VALID_CODE);
+  });
+
+  it('gates the rate limit on each request (bucket is request-scoped)', async () => {
+    // The route must CALL the limiter. Regression guard: if a future
+    // refactor moves the limiter behind a broken conditional, this test
+    // fails before the 429 test does.
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(reserveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('buckets by X-Forwarded-For first entry, trimmed', async () => {
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const req = new NextRequest(
+      new URL(`https://example.test/auth/callback?code=${VALID_CODE}`),
+      { headers: { 'x-forwarded-for': ' 203.0.113.9 , 10.0.0.1' } },
+    );
+    await GET(req);
+    expect(reserveSpy).toHaveBeenCalledWith('203.0.113.9');
+  });
+
+  it('falls back to a shared "no-xff" bucket when XFF is missing', async () => {
+    // Fail-closed on missing IP (a la /api/auth/magic-link) would bounce
+    // any user behind an odd proxy chain. Shared bucket is worse for
+    // the attacker (they compete with everyone else) but strictly safer
+    // for legit users.
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(reserveSpy).toHaveBeenCalledWith('no-xff');
   });
 });
 

--- a/apps/web/tests/unit/auth-callback-route.test.ts
+++ b/apps/web/tests/unit/auth-callback-route.test.ts
@@ -153,6 +153,17 @@ describe('GET /auth/callback — input validation (no Supabase call)', () => {
     expect(exchangeCodeForSession).not.toHaveBeenCalled();
   });
 
+  it('redirects to ?error=invalid_request when code is below MIN_CODE_LEN by one (council bugs r5)', async () => {
+    // Boundary guard: MIN_CODE_LEN = 16. A code of exactly 15 chars must
+    // be rejected. Pairs with the "accepts 16" success test below.
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${'a'.repeat(15)}`));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'invalid_request',
+    );
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
   it('redirects to ?error=invalid_request when code exceeds 4KB (also > 2048)', async () => {
     const { GET } = await import('../../app/auth/callback/route');
     const hugeCode = 'a'.repeat(5000);
@@ -233,6 +244,30 @@ describe('GET /auth/callback — success', () => {
     const res = await GET(makeReq(`?code=${VALID_CODE}&next=%2Fadmin`));
     const loc = new URL(res.headers.get('location') ?? '');
     expect(loc.pathname).toBe('/');
+  });
+
+  it('accepts a code of exactly MIN_CODE_LEN=16 chars (council bugs r5 boundary)', async () => {
+    const minCode = 'a'.repeat(16);
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${minCode}`));
+    expect(new URL(res.headers.get('location') ?? '').pathname).toBe('/');
+    expect(exchangeCodeForSession).toHaveBeenCalledWith(minCode);
+  });
+
+  it('accepts a code of exactly MAX_CODE_LEN=2048 chars (council bugs r5 boundary)', async () => {
+    const maxCode = 'a'.repeat(2048);
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${maxCode}`));
+    expect(new URL(res.headers.get('location') ?? '').pathname).toBe('/');
+    expect(exchangeCodeForSession).toHaveBeenCalledWith(maxCode);
   });
 
   it('uses the first `code` value when duplicated (council bugs r3)', async () => {

--- a/apps/web/tests/unit/auth-callback-route.test.ts
+++ b/apps/web/tests/unit/auth-callback-route.test.ts
@@ -1,0 +1,384 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Integration test for GET /auth/callback — the PKCE landing route that
+// exchanges a Supabase Auth code for a session cookie, then redirects the
+// user to the dashboard.
+//
+// Non-negotiables this suite enforces (plan §Non-negotiables + council
+// rounds r1 / r2 / r3 on PR #22):
+//
+//   1. [security] console.error is never called with any argument
+//      containing `code`, `access_token`, or `refresh_token` substrings
+//      under ANY branch. Single most important safeguard per the
+//      security persona.
+//   2. [security] The success redirect destination is hardcoded to `/`.
+//      No caller-supplied query parameter (e.g. `redirect_to`, `next`)
+//      may influence it. Open-redirect guard.
+//   3. [bugs] Input validation happens BEFORE any Supabase call.
+//      Missing / empty / whitespace / oversized / non-URL-safe-base64
+//      `code` values must redirect to /auth?error=invalid_request
+//      without invoking the stub.
+//   4. [bugs] Every failure branch — including `data.session: null`,
+//      unparseable JSON from Supabase, and generic thrown Errors — maps
+//      to a known error kind and 302s to /auth?error=<kind>. The route
+//      never returns a 500.
+//
+// The Supabase client is stubbed at the apps/web/lib/supabase module
+// boundary; the real @supabase/ssr and @supabase/supabase-js are not
+// exercised here. That's intentional: this suite tests the route
+// handler's control flow, not library behavior.
+
+const exchangeCodeForSession = vi.fn();
+
+vi.mock('../../lib/supabase', () => ({
+  supabaseForRequest: () => ({
+    auth: { exchangeCodeForSession },
+  }),
+}));
+
+/** URL-safe base64 code of plausible length (32 chars). */
+const VALID_CODE = 'abcdefghijklmnopqrstuvwxyz012345';
+
+function makeReq(search: string): NextRequest {
+  const url = new URL(`https://example.test/auth/callback${search}`);
+  return new NextRequest(url);
+}
+
+/**
+ * Scans every argument of every console.error call for any of the given
+ * forbidden substrings. Fails the test if any is found. `code` is passed
+ * in per-test because it varies; access_token / refresh_token are fixed.
+ */
+function assertNoTokenLeaks(errorSpy: ReturnType<typeof vi.spyOn>, code: string) {
+  const forbidden = [code, 'access_token', 'refresh_token'];
+  for (const call of errorSpy.mock.calls) {
+    for (const arg of call) {
+      const repr = typeof arg === 'string' ? arg : safeStringify(arg);
+      for (const needle of forbidden) {
+        if (!needle) continue;
+        expect(repr).not.toContain(needle);
+      }
+    }
+  }
+}
+
+function safeStringify(x: unknown): string {
+  try {
+    return JSON.stringify(x);
+  } catch {
+    return String(x);
+  }
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  exchangeCodeForSession.mockReset();
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// Input validation: redirect to ?error=invalid_request without calling
+// Supabase. The stub must never fire.
+// ---------------------------------------------------------------------------
+describe('GET /auth/callback — input validation (no Supabase call)', () => {
+  it('redirects to ?error=invalid_request when code is missing', async () => {
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(''));
+    expect(res.status).toBe(307);
+    const loc = new URL(res.headers.get('location') ?? '');
+    expect(loc.pathname).toBe('/auth');
+    expect(loc.searchParams.get('error')).toBe('invalid_request');
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+    assertNoTokenLeaks(errorSpy, '');
+  });
+
+  it('redirects to ?error=invalid_request when code is empty', async () => {
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq('?code='));
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'invalid_request',
+    );
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=invalid_request when code is whitespace', async () => {
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq('?code=%20%20%20'));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'invalid_request',
+    );
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=invalid_request when code is too short', async () => {
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq('?code=short'));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'invalid_request',
+    );
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=invalid_request when code exceeds 2048 chars', async () => {
+    const { GET } = await import('../../app/auth/callback/route');
+    const longCode = 'a'.repeat(2049);
+    const res = await GET(makeReq(`?code=${longCode}`));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'invalid_request',
+    );
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=invalid_request when code exceeds 4KB (also > 2048)', async () => {
+    const { GET } = await import('../../app/auth/callback/route');
+    const hugeCode = 'a'.repeat(5000);
+    const res = await GET(makeReq(`?code=${hugeCode}`));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'invalid_request',
+    );
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=invalid_request when code contains null byte', async () => {
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq('?code=abcdefghij%00klmnop'));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'invalid_request',
+    );
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=invalid_request when code contains special chars', async () => {
+    const { GET } = await import('../../app/auth/callback/route');
+    // The specific chars from council bugs r2 — `foo'bar"baz<qux>` padded
+    // to pass the min-length check so the charset check is what rejects.
+    const badCode = `abcdefghijklmnop'bar"baz<qux>`;
+    const res = await GET(makeReq(`?code=${encodeURIComponent(badCode)}`));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'invalid_request',
+    );
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success path: stub resolves without error → 302 to / (HARDCODED).
+// No query param may influence the destination (open-redirect guard).
+// ---------------------------------------------------------------------------
+describe('GET /auth/callback — success', () => {
+  it('redirects to / when exchangeCodeForSession resolves without error', async () => {
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(res.status).toBe(307);
+    const loc = new URL(res.headers.get('location') ?? '');
+    expect(loc.pathname).toBe('/');
+    expect(loc.searchParams.has('error')).toBe(false);
+    expect(exchangeCodeForSession).toHaveBeenCalledTimes(1);
+    expect(exchangeCodeForSession).toHaveBeenCalledWith(VALID_CODE);
+    assertNoTokenLeaks(errorSpy, VALID_CODE);
+  });
+
+  it('ignores extraneous ?redirect_to=evil.com — redirect stays hardcoded to /', async () => {
+    // Council bugs r2: open-redirect guard. A future magic-link generator
+    // that forwards a `redirect_to` param through the callback must NOT be
+    // able to move a signed-in user to an arbitrary URL.
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(
+      makeReq(`?code=${VALID_CODE}&redirect_to=https://evil.example`),
+    );
+    const loc = new URL(res.headers.get('location') ?? '');
+    expect(loc.origin).toBe('https://example.test');
+    expect(loc.pathname).toBe('/');
+    expect(loc.hostname).not.toContain('evil');
+  });
+
+  it('ignores extraneous ?next= — redirect stays hardcoded to /', async () => {
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}&next=%2Fadmin`));
+    const loc = new URL(res.headers.get('location') ?? '');
+    expect(loc.pathname).toBe('/');
+  });
+
+  it('uses the first `code` value when duplicated (council bugs r3)', async () => {
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}&code=${'b'.repeat(32)}`));
+    expect(exchangeCodeForSession).toHaveBeenCalledTimes(1);
+    // searchParams.get() returns the FIRST occurrence; verify that behavior
+    // is preserved by the route (no "accidentally the last" drift).
+    expect(exchangeCodeForSession).toHaveBeenCalledWith(VALID_CODE);
+    expect(new URL(res.headers.get('location') ?? '').pathname).toBe('/');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Supabase error branches: each known error shape maps to a specific kind.
+// Unknown / unexpected shapes fall through to server_error via the final
+// catch-all. No branch may return a 500 or leak a token.
+// ---------------------------------------------------------------------------
+describe('GET /auth/callback — Supabase error branches', () => {
+  it('maps an expired-code error to ?error=token_expired', async () => {
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: null },
+      error: { message: 'PKCE code has expired', status: 400 },
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'token_expired',
+    );
+    assertNoTokenLeaks(errorSpy, VALID_CODE);
+  });
+
+  it('maps a consumed-code error to ?error=token_used', async () => {
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: null },
+      error: {
+        message: 'Code already used; request a new magic link',
+        status: 400,
+      },
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'token_used',
+    );
+    assertNoTokenLeaks(errorSpy, VALID_CODE);
+  });
+
+  it('maps a 5xx Supabase error to ?error=server_error', async () => {
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: null },
+      error: { message: 'Internal server error', status: 502 },
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'server_error',
+    );
+    assertNoTokenLeaks(errorSpy, VALID_CODE);
+  });
+
+  it('maps a 200 OK with data.session: null to ?error=server_error', async () => {
+    // Council bugs r1: an unexpected but not-erroring response shape.
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: null },
+      error: null,
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'server_error',
+    );
+  });
+
+  it('maps a thrown generic Error to ?error=server_error (never 500)', async () => {
+    // Council bugs r1: final catch-all. Something inside Supabase throws
+    // (unparseable JSON, network, TypeError) — route must not propagate
+    // as a 500.
+    exchangeCodeForSession.mockRejectedValueOnce(new Error('boom'));
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'server_error',
+    );
+  });
+
+  it('maps an unparseable-JSON throw (SyntaxError) to ?error=server_error', async () => {
+    // Council bugs r2: an explicit test for this failure mode.
+    exchangeCodeForSession.mockRejectedValueOnce(
+      new SyntaxError('Unexpected token < in JSON at position 0'),
+    );
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'server_error',
+    );
+  });
+
+  it('maps a non-Error throw to ?error=server_error', async () => {
+    // Defense in depth: Supabase could in theory reject with a non-Error.
+    exchangeCodeForSession.mockRejectedValueOnce('string rejection');
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'server_error',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Token leakage: the console.error spy must never see any token substring.
+// This is deliberately its own describe block so a regression is obvious
+// from the test name in CI output.
+// ---------------------------------------------------------------------------
+describe('GET /auth/callback — no token leakage in logs', () => {
+  const branches: ReadonlyArray<readonly [string, () => void]> = [
+    [
+      'expired',
+      () =>
+        exchangeCodeForSession.mockResolvedValueOnce({
+          data: { session: null },
+          error: { message: 'PKCE code has expired', status: 400 },
+        }),
+    ],
+    [
+      'used',
+      () =>
+        exchangeCodeForSession.mockResolvedValueOnce({
+          data: { session: null },
+          error: { message: 'Code already used', status: 400 },
+        }),
+    ],
+    [
+      '5xx',
+      () =>
+        exchangeCodeForSession.mockResolvedValueOnce({
+          data: { session: null },
+          error: { message: 'upstream down', status: 503 },
+        }),
+    ],
+    [
+      'null-session',
+      () =>
+        exchangeCodeForSession.mockResolvedValueOnce({
+          data: { session: null },
+          error: null,
+        }),
+    ],
+    ['thrown', () => exchangeCodeForSession.mockRejectedValueOnce(new Error('boom'))],
+  ];
+
+  for (const [label, arrange] of branches) {
+    it(`does not log code/access_token/refresh_token on ${label}`, async () => {
+      arrange();
+      const { GET } = await import('../../app/auth/callback/route');
+      await GET(makeReq(`?code=${VALID_CODE}`));
+      assertNoTokenLeaks(errorSpy, VALID_CODE);
+    });
+  }
+});

--- a/apps/web/tests/unit/auth-callback-route.test.ts
+++ b/apps/web/tests/unit/auth-callback-route.test.ts
@@ -433,6 +433,24 @@ describe('GET /auth/callback — rate limiting (council r4 blocker)', () => {
     expect(reserveSpy).toHaveBeenCalledWith('203.0.113.9');
   });
 
+  it('falls back to x-real-ip when x-forwarded-for is absent (council bugs r6)', async () => {
+    // Some deployment targets (non-Vercel edges, local docker, odd
+    // proxy chains) set x-real-ip instead of x-forwarded-for. The
+    // implementation tries XFF first, then XRI, then the shared
+    // no-xff bucket. Lock the XRI branch in.
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const req = new NextRequest(
+      new URL(`https://example.test/auth/callback?code=${VALID_CODE}`),
+      { headers: { 'x-real-ip': '198.51.100.5' } },
+    );
+    await GET(req);
+    expect(reserveSpy).toHaveBeenCalledWith('198.51.100.5');
+  });
+
   it('falls back to a shared "no-xff" bucket when XFF is missing', async () => {
     // Fail-closed on missing IP (a la /api/auth/magic-link) would bounce
     // any user behind an odd proxy chain. Shared bucket is worse for

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@llmwiki/lib-utils": "workspace:*",
-    "@supabase/ssr": "^0.4.0",
+    "@supabase/ssr": "0.4.1",
     "@supabase/supabase-js": "^2.45.0",
     "server-only": "^0.0.1"
   },

--- a/packages/db/src/server.test.ts
+++ b/packages/db/src/server.test.ts
@@ -53,13 +53,13 @@ describe('packages/db/src/server — module import', () => {
   });
 });
 
-describe('supabaseServer()', () => {
+describe('createSupabaseClientForJobs()', () => {
   for (const [label, value] of MISSING_VALUES) {
     it(`throws when NEXT_PUBLIC_SUPABASE_URL is ${label}`, async () => {
       setValid();
       vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', value as string);
-      const { supabaseServer } = await import('./server');
-      expect(() => supabaseServer('cookie=x')).toThrowError(
+      const { createSupabaseClientForJobs } = await import('./server');
+      expect(() => createSupabaseClientForJobs('cookie=x')).toThrowError(
         /NEXT_PUBLIC_SUPABASE_URL/,
       );
     });
@@ -67,8 +67,8 @@ describe('supabaseServer()', () => {
     it(`throws when NEXT_PUBLIC_SUPABASE_ANON_KEY is ${label}`, async () => {
       setValid();
       vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', value as string);
-      const { supabaseServer } = await import('./server');
-      expect(() => supabaseServer('cookie=x')).toThrowError(
+      const { createSupabaseClientForJobs } = await import('./server');
+      expect(() => createSupabaseClientForJobs('cookie=x')).toThrowError(
         /NEXT_PUBLIC_SUPABASE_ANON_KEY/,
       );
     });
@@ -76,10 +76,45 @@ describe('supabaseServer()', () => {
 
   it('returns a client when both required vars are set', async () => {
     setValid();
-    const { supabaseServer } = await import('./server');
-    const client = supabaseServer('cookie=x');
+    const { createSupabaseClientForJobs } = await import('./server');
+    const client = createSupabaseClientForJobs('cookie=x');
     expect(client).toBeDefined();
     expect(typeof (client as { from?: unknown }).from).toBe('function');
+  });
+});
+
+describe('createSupabaseClientForRequest()', () => {
+  const noopCookies = {
+    getAll: () => [],
+    setAll: () => undefined,
+  };
+
+  for (const [label, value] of MISSING_VALUES) {
+    it(`throws when NEXT_PUBLIC_SUPABASE_URL is ${label}`, async () => {
+      setValid();
+      vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', value as string);
+      const { createSupabaseClientForRequest } = await import('./server');
+      expect(() => createSupabaseClientForRequest(noopCookies)).toThrowError(
+        /NEXT_PUBLIC_SUPABASE_URL/,
+      );
+    });
+
+    it(`throws when NEXT_PUBLIC_SUPABASE_ANON_KEY is ${label}`, async () => {
+      setValid();
+      vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', value as string);
+      const { createSupabaseClientForRequest } = await import('./server');
+      expect(() => createSupabaseClientForRequest(noopCookies)).toThrowError(
+        /NEXT_PUBLIC_SUPABASE_ANON_KEY/,
+      );
+    });
+  }
+
+  it('returns a client configured for PKCE when vars + adapter are provided', async () => {
+    setValid();
+    const { createSupabaseClientForRequest } = await import('./server');
+    const client = createSupabaseClientForRequest(noopCookies);
+    expect(client).toBeDefined();
+    expect(typeof (client as { auth?: unknown }).auth).toBe('object');
   });
 });
 

--- a/packages/db/src/server.ts
+++ b/packages/db/src/server.ts
@@ -2,29 +2,78 @@
 // accidental import from a client component fails `next build` at compile
 // time — not at runtime.
 //
-// Factories:
-//   - supabaseServer(cookieHeader) — anon key, scoped to the caller's JWT
-//     carried in the Cookie header. RLS evaluates against auth.uid().
+// === Which factory do I pick? ===
+//
+// There are three factories below. The middle one is the default for HTTP
+// request handlers; the other two are for narrower contexts. Picking the
+// wrong one silently breaks auth, so the naming is deliberately explicit
+// (council arch r2 PR #22).
+//
+//   - createSupabaseClientForRequest(adapter) — READ + WRITE cookies.
+//     Use from Next.js Route Handlers, Server Actions, and Server
+//     Components. Supports the PKCE auth flow: exchangeCodeForSession()
+//     can write the session cookie via the adapter's setAll callback.
+//     apps/web/lib/supabase.ts wraps this with the next/headers cookies()
+//     API.
+//
+//   - createSupabaseClientForJobs(cookieHeader) — READ-ONLY cookies.
+//     Use from Inngest workers, webhook handlers, and any context where
+//     there is no response to carry Set-Cookie. Accepts a raw Cookie
+//     header string so RLS resolves against auth.uid() when a caller JWT
+//     is available. If you pass this to a PKCE exchangeCodeForSession()
+//     call, the session lands on the floor — that's the bug PR #22 was
+//     opened to fix.
+//
 //   - supabaseService() — service-role key, bypasses RLS. Use ONLY in
-//     Inngest workers, webhook handlers, and admin RPCs.
+//     Inngest workers, webhook handlers, and admin RPCs. Never reaches
+//     the client bundle (guarded by server-only).
 //
-// packages/db is framework-agnostic: the caller passes the Cookie string in.
-// apps/web wraps supabaseServer() with next/headers's cookies().toString().
+// === Env read discipline ===
 //
-// Env reads are LAZY — they happen inside each factory on invocation, never
-// at module top level. Module-top-level throws break Next.js's "Collecting
-// page data" build phase for any route that transitively imports this file.
+// Env reads are LAZY — they happen inside each factory on invocation,
+// never at module top level. Module-top-level throws break Next.js's
+// "Collecting page data" build phase for any route that transitively
+// imports this file.
 import 'server-only';
 import { createClient } from '@supabase/supabase-js';
+import { createServerClient, type CookieMethodsServer } from '@supabase/ssr';
 import { requireEnv } from '@llmwiki/lib-utils/env';
 
 /**
- * Server-component / server-action Supabase client. Caller passes the raw
- * Cookie header from the request; Supabase uses it to look up the user's
- * JWT so RLS policies resolve against auth.uid(). Cost: ~0 per call
- * (construction only).
+ * Request-scoped Supabase client that can READ and WRITE cookies.
+ * The caller supplies a cookies adapter with getAll/setAll; we plumb
+ * that into @supabase/ssr's createServerClient and configure the PKCE
+ * auth flow so exchangeCodeForSession() can persist the session via
+ * Set-Cookie on the outgoing response.
+ *
+ * Cost: ~0 per call (local construction; no network).
  */
-export function supabaseServer(cookieHeader: string) {
+export function createSupabaseClientForRequest(cookies: CookieMethodsServer) {
+  const supabaseUrl = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const anonKey = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  return createServerClient(supabaseUrl, anonKey, {
+    cookies,
+    auth: {
+      flowType: 'pkce',
+      detectSessionInUrl: false,
+      persistSession: true,
+      autoRefreshToken: true,
+    },
+  });
+}
+
+/**
+ * Read-only Supabase client for cookie-less server contexts (Inngest
+ * workers, webhook handlers, cron). Caller passes a raw Cookie header
+ * string if a user JWT is available so RLS resolves against auth.uid().
+ *
+ * Do NOT use this for auth flows that need to persist a session — the
+ * client has no way to write Set-Cookie. Use createSupabaseClientForRequest
+ * for that.
+ *
+ * Cost: ~0 per call (construction only).
+ */
+export function createSupabaseClientForJobs(cookieHeader: string) {
   const supabaseUrl = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
   const anonKey = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
   return createClient(supabaseUrl, anonKey, {
@@ -35,8 +84,8 @@ export function supabaseServer(cookieHeader: string) {
 
 /**
  * Service-role Supabase client. RLS is bypassed — every call here is
- * trusted. Used by Inngest functions (ingest pipeline, watchdog, onFailure
- * hook) and admin server actions.
+ * trusted. Used by Inngest functions (ingest pipeline, watchdog,
+ * onFailure hook) and admin server actions.
  *
  * Expected call volume: once per Inngest step across the pipeline; not
  * per-request. Cost is zero (local construction).

--- a/packages/lib/ratelimit/src/index.test.ts
+++ b/packages/lib/ratelimit/src/index.test.ts
@@ -3,9 +3,11 @@ import {
   makeTokenBudgetLimiter,
   makeIngestEventLimiter,
   makeMagicLinkLimiter,
+  makeAuthCallbackLimiter,
   RateLimitExceededError,
   RatelimitUnavailableError,
   TOKEN_BUDGET_PER_HOUR,
+  AUTH_CALLBACK_PER_IP_PER_MINUTE,
 } from './index';
 
 interface PipelineLike {
@@ -116,5 +118,31 @@ describe('magic link limiter', () => {
     await expect(lim.reserve('1.2.3.4', 'x@y.z')).rejects.toBeInstanceOf(
       RatelimitUnavailableError,
     );
+  });
+});
+
+describe('auth callback limiter (tier D)', () => {
+  it('AUTH_CALLBACK_PER_IP_PER_MINUTE is 20', () => {
+    expect(AUTH_CALLBACK_PER_IP_PER_MINUTE).toBe(20);
+  });
+
+  it('fails OPEN on upstash failure (transient outage must not deny legit sign-ins)', async () => {
+    // Contrast with every other tier (which fails closed). The callback
+    // is a click-through from a time-boxed magic-link email; a 503 on
+    // Redis outage is a worse UX than dropping the rate-limit briefly,
+    // and Supabase's own project-level rate limits provide the backstop.
+    const redis = { eval: async () => { throw new Error('down'); } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    const lim = makeAuthCallbackLimiter({ redis: redis as any });
+    await expect(lim.reserve('1.2.3.4')).resolves.toBeUndefined();
+  });
+
+  it('accepts auth_callback_ip as a RateLimitExceededError kind', () => {
+    // Type + runtime check: the route handler's instanceof guard
+    // depends on this kind being in the union. If a future refactor
+    // drops the kind from the constructor, this test fails.
+    const err = new RateLimitExceededError('auth_callback_ip', new Date());
+    expect(err.kind).toBe('auth_callback_ip');
+    expect(err).toBeInstanceOf(RateLimitExceededError);
   });
 });

--- a/packages/lib/ratelimit/src/index.ts
+++ b/packages/lib/ratelimit/src/index.ts
@@ -21,7 +21,8 @@ export class RateLimitExceededError extends Error {
       | 'ingest_events'
       | 'token_budget'
       | 'magic_link_ip'
-      | 'magic_link_email',
+      | 'magic_link_email'
+      | 'auth_callback_ip',
     public readonly resetsAt: Date,
   ) {
     super(`rate limit exceeded: ${kind}; resets at ${resetsAt.toISOString()}`);
@@ -136,6 +137,58 @@ export function makeTokenBudgetLimiter(deps: RateLimitDeps = {}) {
   }
 
   return { reserve, refund };
+}
+
+// ----- Tier D: auth callback limiter (anonymous, per-IP, minute window) ---
+//
+// /auth/callback is the click-through landing URL for the magic-link email.
+// It receives a short-lived PKCE code in a query param and calls Supabase
+// Auth's exchangeCodeForSession. A public endpoint + fan-out to an external
+// API = a small but real DOS vector: an attacker can spam bad codes,
+// consuming our server cycles and Supabase's per-project rate budget even
+// though the codes will be rejected.
+//
+// Defensive posture: 20 req / minute / IP — generous enough that a
+// legitimate user's link-click (or a handful of retries) never gets
+// blocked, strict enough that a single-source spam wave hits the ceiling
+// in seconds. FAIL-OPEN on Upstash outage: bouncing a legit sign-in
+// because Redis is down is worse than losing the DOS guard briefly,
+// especially given Supabase's own project-level rate limits as a deeper
+// backstop.
+
+export const AUTH_CALLBACK_PER_IP_PER_MINUTE = 20;
+
+export function makeAuthCallbackLimiter(deps: RateLimitDeps = {}) {
+  const redis = makeRedis(deps);
+  const limiter = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(AUTH_CALLBACK_PER_IP_PER_MINUTE, '1 m'),
+    analytics: false,
+    prefix: 'rl:authcb:ip',
+  });
+
+  /**
+   * Check-and-decrement the per-IP callback counter.
+   *
+   *   - Throws RateLimitExceededError('auth_callback_ip') if over the limit.
+   *   - FAIL-OPEN on Upstash unreachable: resolves without reserving.
+   *     Intentional: a transient Redis outage must not deny a legit
+   *     user's link-click. Supabase's own project rate limits provide
+   *     the deeper backstop against sustained abuse.
+   */
+  async function reserve(ip: string): Promise<void> {
+    let result: Awaited<ReturnType<typeof limiter.limit>>;
+    try {
+      result = await limiter.limit(ip);
+    } catch {
+      return; // fail-OPEN; see docstring for rationale
+    }
+    if (!result.success) {
+      throw new RateLimitExceededError('auth_callback_ip', new Date(result.reset));
+    }
+  }
+
+  return { reserve };
 }
 
 // ----- Tier C: magic-link auth limiter (anonymous endpoint) ---------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/prompts
       '@supabase/ssr':
-        specifier: ^0.4.0
+        specifier: 0.4.1
         version: 0.4.1(@supabase/supabase-js@2.103.3)
       '@supabase/supabase-js':
         specifier: ^2.45.0
@@ -158,7 +158,7 @@ importers:
         specifier: workspace:*
         version: link:../lib/utils
       '@supabase/ssr':
-        specifier: ^0.4.0
+        specifier: 0.4.1
         version: 0.4.1(@supabase/supabase-js@2.103.3)
       '@supabase/supabase-js':
         specifier: ^2.45.0


### PR DESCRIPTION
## Summary

Plan-only PR. Rewrites `.harness/active_plan.md` as a focused per-session plan for the P0 auth callback bug: magic-link email redirects back to `/auth` with tokens in a URL fragment; session never persists.

Root cause (two bugs stacked):
1. Supabase on default `flowType: 'implicit'`; `/auth/callback` expects PKCE.
2. `packages/db/src/server.ts` server client is read-only on cookies — no `Set-Cookie` adapter.

Fix (TDD, single implementation PR to follow):
- Failing integration test for `/auth/callback` first (success + error branches + redaction).
- New `createSupabaseClientForRequest` factory using `@supabase/ssr` `createServerClient` with full getAll/setAll adapter and `flowType: 'pkce'`; rename existing read-only factory to `createSupabaseClientForJobs`.
- Wire the `next/headers` cookies adapter in `apps/web/lib/supabase.ts`; swallow the Server-Component setAll throw.
- Harden `/auth/callback` error mapping; never log `code`/tokens.
- Surface `?error=<kind>` on `/auth` with aria-live messaging.
- Supabase dashboard: Redirect URLs allowlist + both email templates on PKCE form; screenshots in implementation PR.

See the plan file for the full test matrix, inherited non-negotiables, and rollback.

## Council

This PR is the plan-first gate for the fix. Awaiting `.github/workflows/council.yml` synthesis before implementing.

## Test plan

- [ ] Council workflow runs and posts `<!-- council-report -->` comment on this PR.
- [ ] Human reviews the Lead Architect synthesis.
- [ ] Human approves or requests plan revisions.
- [ ] Implementation lands on this PR in small commits (each push re-runs council).

https://claude.ai/code/session_01LkQz8whzZgyGXNRgtDEwG8[]()

![Screenshot_20260421_025921_Chrome.jpg](https://github.com/user-attachments/assets/b5861f88-b905-4e26-87f0-ace09d1a6e0b)

![Screenshot_20260421_025912_Chrome.jpg](https://github.com/user-attachments/assets/b953b33f-7ffa-4250-89de-3eea82d38fad)

![Screenshot_20260421_025901_Chrome.jpg](https://github.com/user-attachments/assets/670d6dd6-5f38-4aea-98be-78ca354e05cb)

