### PR TITLE
docs(harness): plan for issue #26 — auth hardening

### DIFF
--- a/.harness/active_plan.md
+++ b/.harness/active_plan.md
@@ -44,12 +44,18 @@ New and extended tests in `apps/web/lib/supabase.test.ts`, `apps/web/tests/unit/
 **`apps/web/tests/unit/auth-callback-route.test.ts`** — extend:
 
 - `cookie_failure` branch: stub `exchangeCodeForSession` to succeed AND stub the cookie adapter to produce a non-RSC failure → 307 to `/auth?error=cookie_failure`; any cookie successfully written during the transaction is deleted (assert via `store.delete` spy or a Set-Cookie with expired `Max-Age=0`); `console.error` never sees the code, `access_token`, `refresh_token`.
-- `token_used` via double-click: first call with code X returns a session; second call with code X throws a Supabase error whose message contains `already.*used` → second response is 307 `/auth?error=token_used`, no Set-Cookie on the second response.
+- `token_used` via double-click / mail-client prefetch (council security r1 must-do): simulate two sequential `GET` calls to the route handler with the SAME code — the first returns a session (302 `/`), the second hits `exchangeCodeForSession` which throws a Supabase error whose message contains `already.*used` → second response is 307 `/auth?error=token_used`, no `Set-Cookie` on the second response. This is an integration-style test of the full route flow, not a direct stub of the `token_used` path.
+- **Rollback-fail edge case** (council bugs r1): stub the cookie adapter to fail AND stub `cookies().delete` on the rollback path to throw → the route's final catch-all runs, returning a 500 (NextResponse behavior) rather than a 307. Explicit behavior documentation: a failure-within-a-failure-handler is allowed to 500 because the user is already on a degraded path and 500 is greppable; swallowing the secondary throw would hide the bug. Assert status 500 and no token substrings in `console.error`.
+- **Proxy passthrough** (council security r1 top-risk #1): assert that accessing a symbol property (`client[Symbol.iterator]`) and a non-existent string property (`client.__nonexistent__`) returns whatever the underlying Supabase client returns (usually `undefined` for non-existent; whatever `Reflect.get` yields for symbols). Covers the blast-radius concern that a bad Proxy handler could break unrelated auth calls.
 - Regression: missing / empty / whitespace code branches still land at `invalid_request` after the refactor.
 
 **`packages/lib/ratelimit/src/index.test.ts`** — new or extended:
 
-- `makeAuthCallbackLimiter().reserve(ip)` when the underlying `limiter.limit` throws → resolves without error (fail-open preserved) AND `console.error` was called with an object argument that deep-equals `{ alert: true, tier: 'auth_callback_ip', errorName: <name>, ip_bucket: <prefix-or-hash> }`. No raw IP anywhere in the log.
+- `makeAuthCallbackLimiter().reserve(ip)` when the underlying `limiter.limit` throws (string IP) → resolves without error (fail-open preserved) AND `console.error` was called with an object arg containing `{ alert: true, tier: 'auth_callback_ip', errorName: <name>, ip_bucket: <first-3-chars-of-ip> }`.
+- **PII substring guard** (council security r1 must-do): under the fail-open branch, spy on `console.error` and assert that the RAW `ip` string is NOT a substring of ANY argument to ANY call — stringify objects via `JSON.stringify` + scan. Stronger than "ip not passed directly": this catches a future refactor that accidentally includes `ip` inside a nested debug key.
+- `reserve(undefined)` + `limiter.limit` throws → resolves; `ip_bucket === 'unknown'`; no `TypeError`.
+- `reserve(null)` + `limiter.limit` throws → resolves; `ip_bucket === 'unknown'`; no `TypeError`.
+- `reserve('')` + `limiter.limit` throws → resolves; `ip_bucket === 'unknown'`; no `TypeError`.
 - Happy-path (`limit` resolves `success: true`) → resolves; no `console.error`.
 - Over-limit (`limit` resolves `success: false`) → throws `RateLimitExceededError('auth_callback_ip', ...)`; no `console.error`.
 
@@ -68,6 +74,14 @@ export async function supabaseForRequest(): Promise<
 > { … }
 ```
 
+**Method names are STABLE across the plan.** Council arch r1 flagged an
+inconsistency in the first draft (interface used `getWrittenCookieNames`,
+Proxy example used `getCookieWriteNames`). Single source of truth, used
+by every reference in this document and every test assertion:
+
+- `getCookieWriteFailure(): { errorName: string } | null`
+- `getWrittenCookieNames(): readonly string[]`
+
 Behaviorally:
 
 - Keep the existing RSC read-only discriminator (`/cookies.*modif|server\s*action|route\s*handler/i`). That branch silently returns, same as today.
@@ -83,13 +97,20 @@ Behaviorally:
 return new Proxy(client, {
   get(target, prop, receiver) {
     if (prop === 'getCookieWriteFailure') return () => failure;
-    if (prop === 'getCookieWriteNames') return () => [...writtenNames];
+    if (prop === 'getWrittenCookieNames') return () => [...writtenNames];
     return Reflect.get(target, prop, receiver);
   }
 });
 ```
 
-Proxy avoids any collision with Supabase's surface.
+Proxy avoids any collision with Supabase's surface. The handler intercepts
+only our two sentinel property names (string keys); every other access —
+including `Symbol.iterator`, `Symbol.toPrimitive`, `then` (Supabase client
+is thenable-free but future versions might add), and any unknown property
+— flows through `Reflect.get` unchanged. Council security r1 top-risk
+#1: the test suite must exhaustively assert that symbol properties and
+non-existent properties reach the underlying client (see test matrix row
+"proxy — symbol + unknown key passthrough").
 
 ### C. Rollback path in `apps/web/app/auth/callback/route.ts`
 
@@ -143,32 +164,51 @@ Centralize rollback: one helper `rollbackPartialCookies(supabase)` called before
 `apps/web/app/auth/page.tsx` — add to `CALLBACK_ERROR_MESSAGES`:
 
 ```ts
-cookie_failure: 'We couldn't save your sign-in. Please try again.',
+cookie_failure: "We couldn't save your sign-in. Request a new link.",
 ```
 
-Contrast still meets WCAG AA 4.5:1 — uses the same `text-danger` class as existing entries. The existing `aria-live="assertive"` region announces it automatically; no wiring change. Unknown kinds continue to fall through to `GENERIC_CALLBACK_ERROR` (XSS allowlist semantics preserved).
+**Copy choice (council bugs r1):** the first-draft copy ("Please try
+again") is misleading because the PKCE code was successfully consumed
+during the exchange — clicking the same link a second time will map to
+`token_used`, not retry. The user's actual recovery action is to request
+a NEW magic link. This copy matches the sibling messages' cadence
+("Request a new one." / "Request a new link.") and tells the user what
+to do without implying "just click again."
+
+Contrast still meets WCAG AA 4.5:1 — uses the same `text-danger` class
+as existing entries. The existing `aria-live="assertive"` region
+announces it automatically; no wiring change. Unknown kinds continue to
+fall through to `GENERIC_CALLBACK_ERROR` (XSS allowlist semantics
+preserved).
 
 ### E. Fail-open alerting in `packages/lib/ratelimit/src/index.ts`
 
 Change `makeAuthCallbackLimiter().reserve` to log on the fail-open branch:
 
 ```ts
-async function reserve(ip: string): Promise<void> {
+async function reserve(ip: string | null | undefined): Promise<void> {
   let result: Awaited<ReturnType<typeof limiter.limit>>;
   try {
-    result = await limiter.limit(ip);
+    result = await limiter.limit(ip ?? 'no-xff');
   } catch (err) {
     // Fail-OPEN by design — a transient Upstash outage must not deny a legit
     // link-click. But a SILENTLY disabled DOS guard is worse than no guard;
     // a future monitor will grep for `alert: true, tier: 'auth_callback_ip'`
     // in log drain and page the on-call. Shape is stable — do not rename
     // these keys without a search across monitoring config.
+    //
+    // ip_bucket uses ?. + ?? so a missing header can't throw TypeError and
+    // swallow the alert entirely (council bugs r1 top bug — a TypeError
+    // here would make fail-open silent again, re-introducing the very gap
+    // this plan is closing).
     // eslint-disable-next-line no-console
     console.error('[rate-limit] fail-open triggered', {
       alert: true,
       tier: 'auth_callback_ip',
       errorName: err instanceof Error ? err.name : typeof err,
-      ip_bucket: ip.slice(0, 3), // coarse prefix; never the full IP
+      ip_bucket: typeof ip === 'string' && ip.length > 0
+        ? ip.slice(0, 3)
+        : 'unknown',
     });
     return;
   }
@@ -178,7 +218,22 @@ async function reserve(ip: string): Promise<void> {
 }
 ```
 
-`ip_bucket` as a short prefix (3 chars) is a PII-safe coarse locality signal — enough to spot "wave from a /16 subnet" while not re-identifying a user. NO raw IP in the log. Shape-stable keys (`alert`, `tier`, `errorName`, `ip_bucket`) are documented inline as the monitor-grep contract.
+Signature widens to accept `string | null | undefined` (the route's
+`rateLimitBucket` already falls back to `'no-xff'`, but widening the type
+signals that the limiter itself is robust to upstream carelessness).
+
+`ip_bucket` as a short prefix (3 chars) is a PII-safe coarse locality
+signal — enough to spot "wave from a /16 subnet" while not re-identifying
+a user. For a null / undefined / empty `ip`, the bucket becomes the
+literal string `'unknown'` — explicit, greppable, and doesn't hide a
+bug. NO raw IP in the log under ANY branch. Shape-stable keys (`alert`,
+`tier`, `errorName`, `ip_bucket`) are documented inline as the monitor-
+grep contract.
+
+**Alerting defense-in-depth:** the `console.error` call itself can throw
+only on OOM (argument allocation). A try/catch around the log would be
+defending against a fault that, if present, already means the process
+is dying. Out of scope; no wrapping.
 
 ### F. Update call sites (no behavior change)
 
@@ -205,13 +260,47 @@ TypeScript's structural types mean "client with extra methods" is assignable to 
 | callback: exchange throws a setAll-originated error (bubbled through supabase) | rollback precedence — `cookie_failure` beats the catch-all's `server_error` |
 | callback: double-click / prefetch (second GET with consumed code) | 307 `/auth?error=token_used` |
 | ratelimit: limiter.limit resolves success | reserve resolves; no console.error |
-| ratelimit: limiter.limit rejects | reserve resolves (fail-open) AND console.error called once with `{ alert: true, tier: 'auth_callback_ip', errorName, ip_bucket }` |
-| ratelimit: fail-open log never contains raw `ip` value | assert `ip` NOT in any console.error arg |
+| ratelimit: limiter.limit rejects (string ip) | reserve resolves (fail-open) AND console.error called once with `{ alert: true, tier: 'auth_callback_ip', errorName, ip_bucket: <3-char-prefix> }` |
+| ratelimit: limiter.limit rejects, `ip` is `undefined` | reserve resolves; `ip_bucket === 'unknown'`; no TypeError |
+| ratelimit: limiter.limit rejects, `ip` is `null` | reserve resolves; `ip_bucket === 'unknown'`; no TypeError |
+| ratelimit: limiter.limit rejects, `ip === ''` | reserve resolves; `ip_bucket === 'unknown'`; no TypeError |
+| ratelimit: fail-open log never contains raw `ip` string anywhere | stringify every console.error arg and assert `ip` is NOT a substring of any |
+| proxy: access `Symbol.iterator` on client | returns whatever underlying Supabase client returns; no Proxy interception |
+| proxy: access unknown string property | returns `undefined` (passes through `Reflect.get`); no Proxy interception |
+| callback: cookie adapter fails AND `cookies().delete` throws on rollback | status 500 via final catch-all; no token substrings in console.error; explicit test row |
+| callback: double-click — two sequential GETs with same code | first: 302 `/` + Set-Cookie; second: 307 `/auth?error=token_used`, no Set-Cookie |
 | any failure branch (all rows) | console.error spy sees no call whose args contain `code`, `access_token`, `refresh_token` (preserved from PR #22) |
 
-### H. Runbook note
+### H. Runbook — `README.md` `## Monitoring` section
 
-Add one line to the `README.md` "Monitoring" section (or create a stub `## Monitoring` §) describing the `alert: true, tier: 'auth_callback_ip'` log shape as the grep target for fail-open alerting. No infra yet — this is the seam for a future Vercel log drain + Datadog rule.
+Create (not just extend — it doesn't exist yet) a `## Monitoring`
+section in `README.md` after the "Deploy runbook" section. Content
+(exact wording adjustable; the contract is what matters):
+
+> ### Rate-limit fail-open alert
+>
+> The `/auth/callback` rate limiter (`makeAuthCallbackLimiter`) fails
+> OPEN on Upstash outage — a Redis blip cannot be allowed to 503 a
+> legitimate magic-link click. When this happens, the limiter emits a
+> structured log for monitoring to grep:
+>
+> ```
+> [rate-limit] fail-open triggered { alert: true, tier: 'auth_callback_ip', errorName: '<cls>', ip_bucket: '<3-char-prefix-or-unknown>' }
+> ```
+>
+> **Grep contract** (stable — do NOT rename without a coordinated
+> monitoring-config change):
+> - `alert: true` — monitor trigger flag
+> - `tier: 'auth_callback_ip'` — which limiter fired
+>
+> A Vercel log drain routing `alert: true` matches to Datadog / Sentry
+> / PagerDuty is the intended integration seam. Not yet wired — ship
+> the log shape first, wire the drain when a cohort exists.
+
+Council security r1 "must-do before merge" item: this section must
+exist wherever alerting will eventually be configured. `README.md` is
+the visible default; when a runbooks/ directory is created, this
+content moves there and `README.md` links into it.
 
 ## Non-negotiables (inherited + new)
 
@@ -231,8 +320,11 @@ New this plan:
 - **Transactional setAll.** First unexpected throw halts the loop; subsequent writes NOT attempted.
 - **Rollback precedence.** When both `exchangeCodeForSession` and `setAll` produce failures, `cookie_failure` wins over `server_error` — the cookie-write failure is the proximate, actionable cause.
 - **Monitor contract.** `{ alert: true, tier: 'auth_callback_ip' }` key names are a STABLE public contract; renaming requires a coordinated monitoring-config change and a migration note.
-- **No raw IPs in fail-open logs.** Enforced by test.
+- **No raw IPs in fail-open logs.** Enforced by test — raw `ip` NOT a substring of any `console.error` argument.
+- **Null-safe `ip_bucket`.** Use `typeof ip === 'string' && ip.length > 0 ? ip.slice(0, 3) : 'unknown'` — never `ip.slice(...)` unguarded. A TypeError here would swallow the very alert this plan is adding (council bugs r1).
 - **Proxy-wrap the Supabase client.** Do NOT mutate the `@supabase/ssr` return value — library internals can collide on version bumps.
+- **Stable adapter method names.** `getCookieWriteFailure()` and `getWrittenCookieNames()` — single canonical spelling across interface, implementation, tests, and documentation (council arch r1).
+- **Accurate error copy.** `cookie_failure` message directs the user to request a NEW magic link, not to retry the consumed one (council bugs r1).
 
 ## Rollback
 
@@ -273,4 +365,32 @@ If any gate fails, stop and surface the gap.
 
 ## Council history
 
-(empty — awaiting r1)
+- **r1** (PR #28 @ commit `a46682e`, 2026-04-21T10:34:09Z) — **PROCEED**,
+  a11y 9 / arch 10 / bugs 9 / cost 10 / product 9 / security 10. Folded
+  into this plan:
+  - Adapter method naming standardized to `getCookieWriteFailure` /
+    `getWrittenCookieNames` (arch — drift between interface + Proxy
+    example).
+  - `ip_bucket` guarded against non-string `ip` (bugs — `ip.slice(0,3)`
+    on `undefined` would TypeError and swallow the alert).
+  - `cookie_failure` copy rewritten to direct user to request a new
+    link (bugs — "try again" misleading; code already consumed).
+  - Ratelimit test added: raw `ip` string NOT a substring of any
+    `console.error` arg (security must-do).
+  - Callback test added: two sequential GETs with same code for the
+    double-click / prefetch case (security — integration-style, not
+    stub-swapped).
+  - Callback test added: rollback-itself-fails → 500 via final catch-
+    all (bugs — failure-within-failure documented explicitly).
+  - Proxy test added: symbol + unknown-key passthrough via
+    `Reflect.get` (security top-risk #1 — blast-radius guard).
+  - `README.md ## Monitoring` section created with the fail-open log-
+    shape grep contract (security must-do + arch).
+  - Decisions confirmed and explicitly kept:
+    - `server_error` stays as the mapping for 200-OK-with-null-session
+      (no new `exchange_failed` kind) — council product r1 noted this
+      as a judgement call; plan chose (b).
+    - Magic-link-route transactional hardening remains out of scope,
+      tracked as a follow-up.
+    - i18n / Pino structured logger / Datadog wiring all remain
+      out-of-scope nice-to-haves.

--- a/.harness/active_plan.md
+++ b/.harness/active_plan.md
@@ -1,284 +1,276 @@
-# Plan: fix auth callback flow (implicit → PKCE + cookie-writing adapter)
+# Plan: auth hardening — transactional cookie-write + rate-limit fail-open alerting (issue #26)
 
 **Status:** draft, awaiting council + human approval.
-**Branch:** `claude/plan-session-agenda-rRwWN`.
-**Scope:** auth surface — non-negotiable council run required.
-**P0:** without this, no user can complete sign-in.
+**Branch:** `claude/issue-26-auth-hardening`.
+**Scope:** auth surface — non-negotiable council run required. No `[skip council]`.
+**P0:** council r2 on PR #25 explicitly designated #26 as top-priority; its kill criterion was "the next session begins with a task other than the P0-designated issue #26."
 
 ## Problem
 
-First real magic-link email sent after the PR #13/#16/#17 arc landed. The
-email arrives correctly, but clicking the "Confirm" link redirects the
-user back to `/auth` with the session tokens sitting in a URL fragment:
+Two shipped-code bugs that council r1 on PR #25 flagged via reflection review of PR #22 (`e9fc1b4`):
 
-```
-https://llmwiki-study-group.vercel.app/auth#access_token=<JWT>&expires_at=...&refresh_token=...&type=signup
-```
+1. **`setAll` in `apps/web/lib/supabase.ts` is best-effort in an auth context.** The adapter's `setAll` iterates `cookiesToSet`, catches per-write failures, discriminates expected RSC read-only throws (swallow) from unexpected throws (accumulate), and emits a single post-loop summary log for the unexpected ones. For non-auth batch writes that pattern is fine. For session-cookie writes it is not: if one chunk fails and the rest succeed, the route handler's success branch still redirects to `/`, the browser holds a partial/invalid session, the next request bounces through the auth guard back to `/auth`, and the user sees a silent failure after clicking a valid link.
 
-Refreshing `/auth` shows the user still logged out. The session is never
-persisted.
+2. **Tier D rate limiter (`packages/lib/ratelimit/src/index.ts` → `makeAuthCallbackLimiter`) fails open silently on Upstash outage.** Fail-open is the correct tradeoff (a Redis blip must not 503 a legitimate magic-link click); silence is not. If Upstash stays down, the `/auth/callback` DOS guard is gone with zero visibility and no future monitor can alert on it. Council security r2 on PR #25: *"A silently disabled control is not a control."*
 
-## Root cause (two bugs stacked)
+Plus three edge cases the council surfaced on PR #25 r2 that must be covered in the same PR:
 
-1. **Flow mismatch — implicit vs PKCE.** Supabase is on the default
-   `flowType: 'implicit'` (tokens in the URL fragment for client-side
-   parsing). Our `/auth/callback` is written for PKCE (`?code=...` query
-   param + server-side `exchangeCodeForSession`). The email also renders
-   as "Confirm signup" rather than "Magic Link" — both templates can
-   diverge in the Supabase dashboard and both need the PKCE redirect
-   form.
-2. **Cookie adapter is read-only.** `packages/db/src/server.ts:27-34`
-   builds the server client with `@supabase/supabase-js`'s `createClient`
-   and a Cookie-header string. It can READ cookies but has no way to
-   WRITE `Set-Cookie` on the response. Even once PKCE is enabled and
-   `/auth/callback?code=...` fires, `exchangeCodeForSession` succeeds
-   against Supabase Auth and then drops the resulting session on the
-   floor — no cookie is written, so the dashboard's "no session" guard
-   bounces the user straight back to `/auth`.
+3. **Double-click / mail-client prefetch** — Outlook Safe Links and similar consume the single-use PKCE code before the user clicks; the second request hits `exchangeCodeForSession` with a consumed code and should cleanly map to `token_used`. `mapSupabaseError` already targets this (`/\balready\b.*\bused\b|consumed|used_otp|invalid_grant/`), but the code path has no explicit test and no prefetch-as-first-GET scenario exists in the suite.
 
-Both must be fixed together; fixing either alone leaves the user
-broken.
+4. **Supabase 200 OK with missing / malformed session payload** — Today this maps to `server_error` via the `!data?.session` branch. Council r2 suggested either (a) adding a dedicated `exchange_failed` error kind, or (b) documenting the explicit decision to keep the mapping. This plan chooses **(b): keep `server_error`**. Rationale: `server_error` copy ("Could not sign you in right now. Please try again.") correctly invites a retry, which is the right user action for any "Supabase replied but something's off" case — whether the session is null, the body is malformed, or a generic Error was thrown. Splitting into `exchange_failed` adds a user-facing kind that produces identical copy, leaks Supabase internals into our error taxonomy, and expands the `/auth` allowlist for no user benefit. Documented at the `!data?.session` branch in `route.ts` so the non-choice is explicit.
+
+5. **Cross-tab auth state sync** — Explicitly out of scope per the issue; tracked separately.
+
+## Root cause
+
+Both code bugs trace to reasonable-at-the-time decisions that didn't anticipate the auth failure mode:
+
+- The `setAll` accumulator pattern was written assuming best-effort is acceptable because the RSC case dominates. It isn't — Route Handlers and Server Actions both call through this adapter, and for those a partial write IS a real failure.
+- The rate-limiter fail-open was chosen deliberately (`reserve`'s internal docstring: *"a transient Redis outage must not deny a legit user's link-click"*). The design was correct; the observability affordance was missed.
 
 ## Fix (TDD order, single PR)
 
-### A. Failing integration test first
+### A. Failing tests first
 
-New file `apps/web/app/auth/callback/route.integration.test.ts`. Stubs
-`exchangeCodeForSession` and asserts each branch:
+New and extended tests in `apps/web/lib/supabase.test.ts`, `apps/web/tests/unit/auth-callback-route.test.ts`, and `packages/lib/ratelimit/src/index.test.ts` (new file if it doesn't exist). Run before any implementation; all must fail against current `main`.
 
-- **Success:** 302 to `/`, with a `Set-Cookie` carrying `HttpOnly`,
-  `Secure`, `SameSite=Lax`.
-- **Already-used / expired / server error:** 302 to
-  `/auth?error=<kind>` for `kind ∈ {token_used, token_expired,
-  server_error}`. No `Set-Cookie`. No raw `code`, `access_token`, or
-  `refresh_token` in any `console.error` output (assert via
-  `vi.spyOn(console, 'error')`).
-- **Missing / empty / whitespace `code`:** 302 to
-  `/auth?error=invalid_request` before any Supabase call is made
-  (assert the stub is not invoked).
+**`apps/web/lib/supabase.test.ts`** — extend existing suite:
 
-### B. New cookie-writing factory in `packages/db/src/server.ts`
+- RSC read-only throw from `store.set` → `setAll` returns normally; `getCookieWriteFailure()` returns `null`; no `console.error` call.
+- Unexpected throw on cookie #2 of 3 → `getCookieWriteFailure()` returns `{ errorName: <throw.name> }`; `getWrittenCookieNames()` returns only cookie #1's name (successful write BEFORE the failure); no further writes attempted after the failure (assert via call count on a spy `store.set`).
+- Multiple unexpected throws → first unexpected error name is reported; subsequent writes are NOT attempted (transactional halt).
+- Existing partial-write summary-log behavior should be REMOVED (`console.error` is no longer called from setAll — rollback is now the caller's job).
 
-Rename the existing read-only `supabaseServer` → `createSupabaseClientForJobs`
-(Inngest + cookie-less server contexts). Add
-`createSupabaseClientForRequest(adapter)` using `@supabase/ssr`'s
-`createServerClient` with a full `getAll` / `setAll` cookies adapter and
-`flowType: 'pkce'`. Header comment in `server.ts` documenting when to
-pick which — prevents a future consumer from silently re-using the
-read-only factory on a cookie-writing surface (council's naming
-concern).
+**`apps/web/tests/unit/auth-callback-route.test.ts`** — extend:
 
-Update all call sites (one-line import swap each).
+- `cookie_failure` branch: stub `exchangeCodeForSession` to succeed AND stub the cookie adapter to produce a non-RSC failure → 307 to `/auth?error=cookie_failure`; any cookie successfully written during the transaction is deleted (assert via `store.delete` spy or a Set-Cookie with expired `Max-Age=0`); `console.error` never sees the code, `access_token`, `refresh_token`.
+- `token_used` via double-click: first call with code X returns a session; second call with code X throws a Supabase error whose message contains `already.*used` → second response is 307 `/auth?error=token_used`, no Set-Cookie on the second response.
+- Regression: missing / empty / whitespace code branches still land at `invalid_request` after the refactor.
 
-Pin `@supabase/ssr` in `packages/db/package.json`; regenerate
-`pnpm-lock.yaml`.
+**`packages/lib/ratelimit/src/index.test.ts`** — new or extended:
 
-### C. Wire the Next.js adapter in `apps/web/lib/supabase.ts`
+- `makeAuthCallbackLimiter().reserve(ip)` when the underlying `limiter.limit` throws → resolves without error (fail-open preserved) AND `console.error` was called with an object argument that deep-equals `{ alert: true, tier: 'auth_callback_ip', errorName: <name>, ip_bucket: <prefix-or-hash> }`. No raw IP anywhere in the log.
+- Happy-path (`limit` resolves `success: true`) → resolves; no `console.error`.
+- Over-limit (`limit` resolves `success: false`) → throws `RateLimitExceededError('auth_callback_ip', ...)`; no `console.error`.
 
-`supabaseForRequest()` calls `createSupabaseClientForRequest` with the
-`next/headers` `cookies()` adapter. Wrap `setAll` in try/catch —
-Server Components can't set cookies (Next throws), so the catch runs
-there; route handlers and server actions write normally. On catch,
-log at `debug` level with no cookie values (council bugs r1) so the
-swallow isn't silent and a future maintainer misusing the adapter in
-a Server Component can find it.
+### B. Transactional `setAll` in `apps/web/lib/supabase.ts`
 
-Debug log message must explicitly state the expected cause (council
-security r2): `"supabase: setAll failed — expected in Server Component
-context, ignoring"`. Never include cookie values or names in the log
-line.
+Change the factory return shape from `SupabaseClient` to a discriminated object. Two new exported helpers on the returned object expose the adapter's transactional state to the caller:
 
-### D. Harden `apps/web/app/auth/callback/route.ts`
+```ts
+interface CookieWriteState {
+  getCookieWriteFailure(): { errorName: string } | null;
+  getWrittenCookieNames(): readonly string[];
+}
 
-Catch `exchangeCodeForSession` failures explicitly. Map known Supabase
-error shapes to kinds:
+export async function supabaseForRequest(): Promise<
+  SupabaseClient & CookieWriteState
+> { … }
+```
 
-- consumed code → `token_used`
-- expired code → `token_expired`
-- 5xx / network → `server_error`
-- 200 OK with `data.session: null` → `server_error` (council bugs r1)
-- 200 OK with unparseable JSON body → `server_error` via the final
-  catch-all (council bugs r2)
-- any other thrown `Error` → `server_error` via a final catch-all so
-  the route can never return a 500 (council bugs r1)
+Behaviorally:
 
-**Redirect rules (non-negotiable, council bugs r2):** the success
-redirect destination is **hardcoded to `/`**. No query parameter
-(including `redirect_to`, `next`, `returnTo`, or any other caller-
-supplied value) may influence the destination URL. This closes the
-open-redirect vector the bugs persona flagged.
+- Keep the existing RSC read-only discriminator (`/cookies.*modif|server\s*action|route\s*handler/i`). That branch silently returns, same as today.
+- On an UNEXPECTED throw, record `{ errorName }` on a closure-scoped `failure` variable AND **stop iterating** further cookies. This is the transactional part: no partial writes after a failure.
+- On a successful `store.set`, push the cookie name into a `writtenNames` array.
+- Expose `getCookieWriteFailure()` (reads `failure`) and `getWrittenCookieNames()` (snapshot copy of `writtenNames`) on the returned object.
+- DELETE the post-loop `console.error` summary log. Rollback is now the caller's job; the adapter is quiet on both happy and sad paths (the caller logs on rollback).
+- Callers that DON'T care about cookie-write transactionality (dashboard, note page, magic-link route, ingest route) ignore the new methods — zero-behavior-change refactor for them. They get the returned client as before via the spread.
 
-**Input validation (defense-in-depth, council security r2):** before
-invoking `exchangeCodeForSession`, validate the `code` param against a
-plausible charset (URL-safe base64 alphabet: `[A-Za-z0-9_\-]`) and
-length bound (reject `<16` or `>2048` chars). Fail to `invalid_request`.
-This is belt-and-suspenders; Supabase also validates, but a malformed
-code should never reach the network.
+**Attach via Proxy, not by mutating the Supabase client.** `createSupabaseClientForRequest` returns a `SupabaseClient` from `@supabase/ssr`; adding properties to that object risks clobbering library internals across version bumps. Instead wrap it:
 
-**Logging rules (non-negotiable):** never log `code`, `access_token`,
-or `refresh_token` under any branch. Log only the error kind + a
-sanitized Supabase error message. Redirect to `/auth?error=<kind>` on
-every failure branch.
+```ts
+return new Proxy(client, {
+  get(target, prop, receiver) {
+    if (prop === 'getCookieWriteFailure') return () => failure;
+    if (prop === 'getCookieWriteNames') return () => [...writtenNames];
+    return Reflect.get(target, prop, receiver);
+  }
+});
+```
 
-### E. Surface the error on `/auth/page.tsx`
+Proxy avoids any collision with Supabase's surface.
 
-Read `?error=` via `useSearchParams`; render an `aria-live="assertive"`
-message with kind-specific copy selected by an **allowlist** (switch /
-object map) on the parameter value. The raw query-param value is
-NEVER rendered into the DOM — any unknown kind falls through to a
-generic "Sign-in failed. Request a new link." message. This closes
-the XSS vector the security persona flagged at r1.
+### C. Rollback path in `apps/web/app/auth/callback/route.ts`
 
-Copy:
+After `exchangeCodeForSession` returns (or throws), BEFORE the success redirect, call `supabase.getCookieWriteFailure()`. If non-null:
 
-- `token_used` → "This sign-in link has already been used. Request a new one."
-- `token_expired` → "This sign-in link has expired. Request a new one."
-- `server_error` → "Could not sign you in right now. Please try again."
-- `invalid_request` → "Sign-in link was invalid. Request a new one."
-- any other value → "Sign-in failed. Request a new link."
+1. Iterate `supabase.getCookieWriteNames()` and for each name, call `(await cookies()).delete(name)`. This clears any partially-written session cookies from the current response.
+2. `console.error('[auth/callback] sign-in failed', { kind: 'cookie_failure', errorName: failure.errorName })`. Token-leak guard still applies — `errorName` is a class name, never a value.
+3. 307 to `/auth?error=cookie_failure`.
 
-Message text must meet **WCAG AA 4.5:1** contrast against its
-background (a11y r1).
+Ordering nuance: a failure on cookie #1 means `writtenNames` is empty and the rollback loop is a no-op — correct. A failure mid-stream means we clear the cookies we did write. The route MUST check `getCookieWriteFailure()` AFTER `exchangeCodeForSession` regardless of whether that call succeeded or threw — a throw from setAll bubbles up as a generic Error through the supabase call, and the existing catch-all would currently mis-map it to `server_error`. We want `cookie_failure` precedence.
 
-Form stays visible below the message so the user can request a fresh
-link without extra clicks.
+Concretely: in the `try { exchangeCodeForSession } catch (err) { … }` block, add a pre-check in the `catch` branch:
 
-### F. Supabase dashboard (manual, pre-merge)
+```ts
+} catch (err) {
+  const failure = supabase.getCookieWriteFailure?.();
+  if (failure) {
+    // Rollback + redirect flow below.
+  } else {
+    console.error('[auth/callback] unexpected exchange failure', {
+      kind: 'server_error',
+      errorName: err instanceof Error ? err.name : typeof err,
+    });
+    failureKind = 'server_error';
+  }
+}
+```
 
-1. **Auth → URL Configuration → Redirect URLs allowlist:** only
-   `https://llmwiki-study-group.vercel.app/auth/callback` plus any
-   preview-URL pattern. No wildcards, no non-project origins.
-   Complements PR #17's `APP_BASE_URL`-only server policy.
-2. **Auth → Email Templates → Confirm signup AND Magic Link:** both
-   must use `{{ .SiteURL }}/auth/callback?code={{ .TokenHash }}` (PKCE
-   form). Default templates still carry the fragment form; both
-   templates need editing.
-3. Screenshot both sections; attach to the PR description as
-   pre-merge verification.
+And on the success path (after the try/catch):
 
-### G. Runbook update
+```ts
+if (failureKind === null) {
+  const failure = supabase.getCookieWriteFailure?.();
+  if (failure) {
+    failureKind = 'cookie_failure';
+    console.error('[auth/callback] sign-in failed', {
+      kind: 'cookie_failure',
+      errorName: failure.errorName,
+    });
+    // rollback below
+  }
+}
+```
 
-Add §F to `README.md` "Deploy runbook" so the dashboard steps are in
-the checklist for any future environment.
+Centralize rollback: one helper `rollbackPartialCookies(supabase)` called before the error-redirect `return`.
 
-## Test matrix
+`ErrorKind` union gets a new `'cookie_failure'` member; `mapSupabaseError` does NOT emit it (cookie_failure is not a Supabase-origin error kind).
+
+### D. `/auth` page copy for `cookie_failure`
+
+`apps/web/app/auth/page.tsx` — add to `CALLBACK_ERROR_MESSAGES`:
+
+```ts
+cookie_failure: 'We couldn't save your sign-in. Please try again.',
+```
+
+Contrast still meets WCAG AA 4.5:1 — uses the same `text-danger` class as existing entries. The existing `aria-live="assertive"` region announces it automatically; no wiring change. Unknown kinds continue to fall through to `GENERIC_CALLBACK_ERROR` (XSS allowlist semantics preserved).
+
+### E. Fail-open alerting in `packages/lib/ratelimit/src/index.ts`
+
+Change `makeAuthCallbackLimiter().reserve` to log on the fail-open branch:
+
+```ts
+async function reserve(ip: string): Promise<void> {
+  let result: Awaited<ReturnType<typeof limiter.limit>>;
+  try {
+    result = await limiter.limit(ip);
+  } catch (err) {
+    // Fail-OPEN by design — a transient Upstash outage must not deny a legit
+    // link-click. But a SILENTLY disabled DOS guard is worse than no guard;
+    // a future monitor will grep for `alert: true, tier: 'auth_callback_ip'`
+    // in log drain and page the on-call. Shape is stable — do not rename
+    // these keys without a search across monitoring config.
+    // eslint-disable-next-line no-console
+    console.error('[rate-limit] fail-open triggered', {
+      alert: true,
+      tier: 'auth_callback_ip',
+      errorName: err instanceof Error ? err.name : typeof err,
+      ip_bucket: ip.slice(0, 3), // coarse prefix; never the full IP
+    });
+    return;
+  }
+  if (!result.success) {
+    throw new RateLimitExceededError('auth_callback_ip', new Date(result.reset));
+  }
+}
+```
+
+`ip_bucket` as a short prefix (3 chars) is a PII-safe coarse locality signal — enough to spot "wave from a /16 subnet" while not re-identifying a user. NO raw IP in the log. Shape-stable keys (`alert`, `tier`, `errorName`, `ip_bucket`) are documented inline as the monitor-grep contract.
+
+### F. Update call sites (no behavior change)
+
+Touch every call site of `supabaseForRequest()` to confirm the new return type compiles:
+
+- `apps/web/app/page.tsx` — ignore new methods; uses `.auth.getUser()` only.
+- `apps/web/app/note/[slug]/page.tsx` — same.
+- `apps/web/app/api/ingest/route.ts` — same.
+- `apps/web/app/api/auth/magic-link/route.ts` — same. (Magic-link cookie writes are code-verifier chunks; a failure here would break the subsequent callback. Out of scope to harden this route in the same PR; tracked as a follow-up issue if the proxy surface shows it's useful.)
+- `apps/web/app/auth/callback/route.ts` — uses the new methods.
+
+TypeScript's structural types mean "client with extra methods" is assignable to "client" everywhere; no cast needed.
+
+### G. Test matrix (additions to PR #22's matrix)
 
 | Branch | Expected |
 |---|---|
-| valid `code`, stub returns session | 302 `/`, `Set-Cookie` HttpOnly+Secure+SameSite=Lax, `Path=/` |
-| stub throws `token_used` | 302 `/auth?error=token_used`, no Set-Cookie |
-| stub throws `token_expired` | 302 `/auth?error=token_expired`, no Set-Cookie |
-| stub throws 5xx / network | 302 `/auth?error=server_error`, no Set-Cookie |
-| stub returns 200 with `data.session: null` | 302 `/auth?error=server_error`, no Set-Cookie (council r1) |
-| stub throws generic `Error` | 302 `/auth?error=server_error`, no Set-Cookie, no 500 (council r1) |
-| missing `code` param | 302 `/auth?error=invalid_request`, stub NOT called |
-| empty `code` | same as missing |
-| whitespace-only `code` | same as missing |
-| `code` >4KB | 302 `/auth?error=invalid_request`, stub NOT called (council r1) |
-| `code` contains null byte / non-URL-safe chars | 302 `/auth?error=invalid_request`, stub NOT called (council r1) |
-| `code` outside URL-safe base64 alphabet (e.g. `foo'bar"baz<qux>`) | 302 `/auth?error=invalid_request`, stub NOT called (council bugs r2) |
-| `code` valid + extraneous `redirect_to=https://evil.com` | 302 to `/` (hardcoded), NOT to the supplied URL (council bugs r2 — open-redirect guard) |
-| stub returns 200 with unparseable JSON body | 302 `/auth?error=server_error` via final catch-all (council bugs r2) |
-| any failure branch | `console.error` spy sees no call whose args contain `code` / `access_token` / `refresh_token` (council r1) |
+| adapter `setAll` throws RSC read-only message | `getCookieWriteFailure()` is null; loop continues; no console.error |
+| adapter `setAll` throws unexpected error on cookie #1 | `getCookieWriteFailure()` reports; `getCookieWriteNames()` empty; remaining writes SKIPPED |
+| adapter `setAll` throws unexpected on cookie #2 of 3 | failure reported once; names = [#1]; write #3 NOT attempted |
+| callback: exchange success + cookie adapter healthy | 302 `/`, Set-Cookie on all chunks |
+| callback: exchange success + cookie adapter throws unexpected mid-stream | 307 `/auth?error=cookie_failure`, delete-me Set-Cookie clearing partial, no token substrings in console.error |
+| callback: exchange throws, cookie adapter healthy | 307 `/auth?error=<mapped-kind>`, no rollback needed, existing behavior |
+| callback: exchange throws a setAll-originated error (bubbled through supabase) | rollback precedence — `cookie_failure` beats the catch-all's `server_error` |
+| callback: double-click / prefetch (second GET with consumed code) | 307 `/auth?error=token_used` |
+| ratelimit: limiter.limit resolves success | reserve resolves; no console.error |
+| ratelimit: limiter.limit rejects | reserve resolves (fail-open) AND console.error called once with `{ alert: true, tier: 'auth_callback_ip', errorName, ip_bucket }` |
+| ratelimit: fail-open log never contains raw `ip` value | assert `ip` NOT in any console.error arg |
+| any failure branch (all rows) | console.error spy sees no call whose args contain `code`, `access_token`, `refresh_token` (preserved from PR #22) |
 
-## Non-negotiables (inherited + council r1)
+### H. Runbook note
 
-Pre-existing (PR #21 handoff):
+Add one line to the `README.md` "Monitoring" section (or create a stub `## Monitoring` §) describing the `alert: true, tier: 'auth_callback_ip'` log shape as the grep target for fail-open alerting. No infra yet — this is the seam for a future Vercel log drain + Datadog rule.
 
-- **No logging** of `code` or session tokens in any branch.
-- **Pin** `@supabase/ssr`; lockfile updated.
-- **Redirect URLs allowlist** locked to `APP_BASE_URL` pre-merge,
-  screenshot in PR body.
-- **Error surfacing** on `/auth` — no silent redirect.
-- **Council required** on this surface. No `[skip council]`.
-- **RLS unchanged.** Anon key only; no service-role exposure.
+## Non-negotiables (inherited + new)
 
-Added by council r1:
+Inherited from PR #22:
 
-- **[security]** Integration test MUST `vi.spyOn(console, 'error')`
-  and assert no call's arguments contain `code`, `access_token`, or
-  `refresh_token` substrings under any failure branch. Single most
-  important safeguard per the security persona.
-- **[security]** `/auth/page.tsx` error rendering MUST use an
-  allowlist (switch / object map) on the `error` query-param value.
-  The raw param value is never rendered; unknown kinds fall through
-  to a generic message. Closes the XSS vector.
-- **[security]** Supabase dashboard screenshots (Redirect URLs
-  allowlist AND both email templates on the PKCE redirect form) must
-  be in the implementation PR body before merge.
-- **[a11y]** Error message MUST meet WCAG AA 4.5:1 contrast against
-  background. Verify at implementation.
+- **No logging** of `code`, `access_token`, or `refresh_token` in any branch. Tests spy + assert.
+- **`@supabase/ssr` pinned.** No version bump in this PR.
+- **Redirect URLs allowlist** unchanged. No dashboard edits.
+- **Success redirect hardcoded to `/`.** No caller-supplied query param can influence destination.
+- **RLS unchanged.** Anon key only.
+- **`/auth` error rendering stays allowlist-only** (raw `?error` value never interpolated).
+- **WCAG AA 4.5:1** contrast on new error copy.
+- **Council required.** No `[skip council]`.
 
-Added by council r2:
+New this plan:
 
-- **[bugs]** Success-redirect destination is **hardcoded to `/`**.
-  No caller-supplied query param (`redirect_to`, `next`, etc.) may
-  influence the target URL. Tested by the extraneous-param row in
-  the matrix above. Open-redirect guard.
-- **[bugs]** Unparseable JSON from `exchangeCodeForSession` maps to
-  `server_error` via the final catch-all; explicit test row required.
+- **Transactional setAll.** First unexpected throw halts the loop; subsequent writes NOT attempted.
+- **Rollback precedence.** When both `exchangeCodeForSession` and `setAll` produce failures, `cookie_failure` wins over `server_error` — the cookie-write failure is the proximate, actionable cause.
+- **Monitor contract.** `{ alert: true, tier: 'auth_callback_ip' }` key names are a STABLE public contract; renaming requires a coordinated monitoring-config change and a migration note.
+- **No raw IPs in fail-open logs.** Enforced by test.
+- **Proxy-wrap the Supabase client.** Do NOT mutate the `@supabase/ssr` return value — library internals can collide on version bumps.
 
 ## Rollback
 
-Revert the PR. User returns to current state: email delivers, sign-in
-never completes. No additional regressions — this PR only touches the
-auth callback + its server-client factory; it does not migrate schema
-or change RLS.
+Revert the PR. The system returns to:
 
-## Out of scope for this PR
+- `setAll` best-effort + summary log (the shipped PR #22 behavior).
+- Silent fail-open on Upstash outage (the shipped PR #22 behavior).
+- No `cookie_failure` kind; a partial-write bug presents as a silent login-loop (the known pre-fix failure mode).
 
-- Framework specialist persona (#18) — queued as next priority after
-  this P0 lands.
-- Playwright nonce smoke test (#20).
-- `/diag` removal (#12), CSP `report-uri` (#14), `style-src`
-  hardening (#15).
-- **i18n of the new error strings.** Hard-coded English copy is
-  acceptable for the P0 fix; externalization is a follow-up
-  (council a11y r1 noted this as a nice-to-have, not a blocker).
-- `pnpm audit` in CI. Council security r1 nice-to-have; separate
-  issue if we want it.
-- **`Set-Cookie` header exceeding browser max size.** Council bugs
-  r2 flagged this as a theoretical failure mode (browser silently
-  drops oversize cookies). Cookie name and size are controlled by
-  `@supabase/ssr`, which splits large sessions into chunked cookies
-  under the 4KB-per-cookie browser limit. Not mitigable in our code.
-  If sessions routinely exceed limits, that's a Supabase-library
-  issue to escalate — out of scope for this P0.
-- Any v1 feature work.
+No schema migration, no RLS change, no dashboard edit — pure revert is clean.
 
-## Success + kill criteria (council product r1)
+## Out of scope
 
-- **Success metric:** count of 302s from `/auth/callback` to `/` per
-  day (successful sign-ins). Track via existing server logs — no new
-  telemetry infra.
-- **Failure metric:** count of 302s from `/auth/callback` to
-  `/auth?error=<kind>` bucketed by kind.
-- **Kill criteria:** if total failure rate > 1% of sign-in attempts
-  24h after merge, revert the PR.
-- **Cost:** $0 marginal. Supabase Auth is MAU-billed, not per-call.
+- Magic-link route (`/api/auth/magic-link`) transactional hardening. Tracked as follow-up if the proxy surface proves useful.
+- Cross-tab auth state sync (council r2 explicit out-of-scope).
+- `exchange_failed` as a distinct user-facing kind (see Problem §4 — decision documented; keep `server_error`).
+- Datadog / Sentry / Vercel log drain integration itself. This PR ships the log SHAPE; monitoring wiring is a separate effort with its own cost line.
+- Dedicated `pgTAP` migration-flake fix (#7).
+- `/diag` removal (#12), Playwright smoke (#20), framework persona (#18).
+- i18n of new error copy (council a11y r1 nice-to-have, unchanged decision).
 
-## Council history
+## Success + kill criteria
 
-- **r1** (PR #22 @ commit `1ae040f`, 2026-04-19T18:48:54Z) — PROCEED,
-  a11y 8 / arch 10 / bugs 9 / cost 10 / product 10 / security 9. Four
-  new non-negotiables folded into this plan.
-- **r2** (PR #22 @ commit `ea3fc8a`, 2026-04-19T18:56:52Z) — PROCEED,
-  a11y **9** / arch 10 / bugs 9 / cost 10 / product 10 / security 9.
-  Five additions folded: open-redirect guard, unparseable-JSON test,
-  special-char code test, debug-log wording, defense-in-depth
-  charset/length validation on `code`. Full report:
-  [PR #22 council comment](https://github.com/Anguijm/LLMwiki_StudyGroup/pull/22#issuecomment-4276576994).
+- **Success metric:** count of 307s from `/auth/callback` to `/auth?error=cookie_failure` per day (should round to zero — when it's non-zero, monitor fires). Alerting signal presence tracked via log-drain grep.
+- **Failure metric:** same count, trending up or spiking on a single request hot-path. OR: `alert: true` log fires without a concurrent Upstash incident ticket.
+- **Kill criteria:** revert if cookie_failure > 0.1% of sign-ins 48h post-merge AND no Upstash / cookie library incident correlates — that means we introduced a regression in the happy path.
+- **Cost:** $0 marginal. No new API calls. `console.error` volume negligible.
 
-## Approval checklist (CLAUDE.md gate)
+## Approval checklist (CLAUDE.md hard gate)
 
 Before writing implementation code, all three must be true:
 
-1. This file is committed on `claude/plan-session-agenda-rRwWN` and
-   pushed to origin.
-2. A PR is open against `main`; the latest `<!-- council-report -->`
-   comment from `.github/workflows/council.yml` was posted against a
-   commit SHA ≥ the commit that last modified this plan.
-3. The human has typed an explicit `approved` / `ship it` / `proceed`
-   after seeing (1) and (2).
+1. This file committed on `claude/issue-26-auth-hardening` and pushed to origin.
+2. PR open against `main`; latest `<!-- council-report -->` comment from `.github/workflows/council.yml` posted against a commit SHA ≥ the commit that last modified this plan.
+3. Human typed explicit `approved` / `ship it` / `proceed` after seeing (1) and (2).
 
 If any gate fails, stop and surface the gap.
+
+## Council history
+
+(empty — awaiting r1)

--- a/README.md
+++ b/README.md
@@ -392,6 +392,41 @@ in Vercel.
 
 ---
 
+## Monitoring
+
+### Rate-limit fail-open alert (`/auth/callback`)
+
+The `/auth/callback` rate limiter (`makeAuthCallbackLimiter` in
+`packages/lib/ratelimit`) fails **open** on Upstash outage — a Redis
+blip cannot 503 a legitimate magic-link click. When this happens the
+limiter emits a structured `console.error` line for monitoring to grep:
+
+```
+[rate-limit] fail-open triggered { alert: true, tier: 'auth_callback_ip', errorName: '<cls>', ip_bucket: '<3-char-prefix-or-unknown>' }
+```
+
+**Grep contract (STABLE — do NOT rename without a coordinated monitor
+config change):**
+
+| Key | Meaning |
+|---|---|
+| `alert: true` | Monitor trigger flag. |
+| `tier: 'auth_callback_ip'` | Which limiter fired. |
+| `errorName: string` | Thrown error's `.name` (or `typeof` for non-Error throws). Class identifier only — no payload, no message, no stack. |
+| `ip_bucket: string` | 3-character prefix of the IP for coarse locality, or the literal `'unknown'` if the IP was missing. **Never** the full IP. |
+
+**Intended integration:** a Vercel log drain routing `alert: true`
+matches to Datadog / Sentry / PagerDuty is the seam. Not yet wired —
+ship the log shape first, wire the drain when a cohort exists.
+
+**Why we care:** a silently disabled control is not a control. If
+Upstash stays down, the DOS guard on `/auth/callback` disappears with
+zero visibility. Council r2 on PR #25 (the shipped-code review that
+surfaced this gap) treated alerting as the primary mitigation; this
+log is what makes the fail-open recoverable.
+
+---
+
 ## Database Schema (Key Tables)
 
 ```sql

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -5,7 +5,8 @@
 // the @supabase/ssr setAll adapter in apps/web/lib/supabase.ts) and
 // redirects to the dashboard.
 //
-// Security posture (plan PR #22, council rounds r1 / r2 / r3 / r4):
+// Security posture (plan PR #22, council rounds r1 / r2 / r3 / r4;
+// PR #28 / issue #26 adds the cookie_failure branch):
 //
 //   - Per-IP rate limit (20 req / min, fail-open on Upstash outage).
 //     /auth/callback is a public endpoint that fans out to Supabase
@@ -13,35 +14,38 @@
 //     consume our server + Supabase's per-project rate budget (council
 //     security r4 blocker: non-negotiable on public endpoints with
 //     external API fan-out). Fail-open intentional: a Redis outage
-//     must not 503 a legit magic-link click.
+//     must not 503 a legit magic-link click. The limiter emits a
+//     monitorable `alert: true, tier: 'auth_callback_ip'` log on
+//     fail-open (PR #28 / issue #26).
 //
 //   - Input validation runs BEFORE the Supabase call. Missing /
 //     empty / whitespace / too-short / too-long / non-URL-safe `code`
 //     values redirect to /auth?error=invalid_request immediately.
-//     Defense in depth: Supabase also validates, but a malformed code
-//     should never touch the network.
 //
-//   - Every failure branch — Supabase-shaped errors, a 200 OK with
-//     `data.session: null`, unparseable JSON responses, and generic
-//     thrown Errors — maps to a known error kind and 307s to
+//   - Every failure branch maps to a known kind and 307s to
 //     /auth?error=<kind>. The final catch-all guarantees this route
-//     never returns a 500 (council bugs r1 / r2 / r3).
+//     never returns a 500 for auth failures (council bugs r1 / r2 / r3).
+//     The one exception is a rollback-itself-fails edge case where
+//     `cookies().delete()` throws on the cookie_failure recovery path —
+//     that escalates to 500 by design (council bugs r1 PR #28: silent
+//     swallow of a failure-within-a-failure-handler hides the bug).
 //
 //   - The success redirect is HARDCODED to `/`. No caller-supplied
-//     query parameter (`redirect_to`, `next`, etc.) may influence the
-//     destination URL. Forwarding an attacker-controlled URL here
-//     would be an open-redirect vector (council bugs r2). If a
-//     post-sign-in destination is ever needed, store it server-side
-//     (e.g., a cookie set at magic-link send time) — never in the
-//     callback query string.
+//     query parameter may influence the destination (open-redirect
+//     guard, council bugs r2).
+//
+//   - On a partial session-cookie write (@supabase/ssr setAll halts
+//     mid-stream), the route deletes any cookies that DID write before
+//     the halt and 307s to /auth?error=cookie_failure. This takes
+//     precedence over `server_error` when the setAll throw bubbles
+//     through exchangeCodeForSession (PR #28 / issue #26).
 //
 //   - Logs NEVER contain the `code`, `access_token`, or `refresh_token`
 //     values. Only the mapped error kind and (optionally) the thrown
-//     error's class name are emitted. The integration test suite at
-//     apps/web/tests/unit/auth-callback-route.test.ts spies on
-//     console.error and fails if any of those substrings appear.
+//     error's class name are emitted. Spy-enforced in the test suite.
 
 import { NextResponse, type NextRequest } from 'next/server';
+import { cookies } from 'next/headers';
 import { supabaseForRequest } from '../../../lib/supabase';
 import {
   makeAuthCallbackLimiter,
@@ -50,7 +54,12 @@ import {
 
 export const runtime = 'nodejs';
 
-type ErrorKind = 'invalid_request' | 'token_expired' | 'token_used' | 'server_error';
+type ErrorKind =
+  | 'invalid_request'
+  | 'token_expired'
+  | 'token_used'
+  | 'server_error'
+  | 'cookie_failure';
 
 // URL-safe base64 alphabet. Supabase PKCE codes are opaque strings within
 // this character set; anything else is an obvious probe / garbage and is
@@ -91,8 +100,7 @@ function rateLimitBucket(req: NextRequest): string {
  * match on message substrings with explicit fall-through to
  * `server_error`. If Supabase changes its error copy in a future
  * release, the result is more "server_error" toasts rather than a
- * crash — acceptable graceful degradation (council security r4
- * nice-to-have: revisit if Supabase ever exposes stable codes).
+ * crash — acceptable graceful degradation.
  */
 function mapSupabaseError(err: { message?: string; status?: number } | null): ErrorKind {
   if (!err) return 'server_error';
@@ -125,6 +133,23 @@ function tooManyRequests(resetsAt: Date): NextResponse {
   });
 }
 
+/**
+ * Delete partial session cookies when the setAll adapter halted the
+ * transaction. Throws are allowed to propagate — a failure here is a
+ * genuine bug (a frozen cookie store, a Next.js guard change) and
+ * swallowing would hide it. The route's outer `try` catches the throw
+ * and returns 500 explicitly so the failure mode is obvious in logs
+ * and CI rather than presenting as a weird inconsistent redirect.
+ * Council bugs r1 on PR #28.
+ */
+async function rollbackPartialCookies(names: readonly string[]): Promise<void> {
+  if (names.length === 0) return;
+  const store = await cookies();
+  for (const name of names) {
+    store.delete(name);
+  }
+}
+
 export async function GET(req: NextRequest): Promise<NextResponse> {
   // 1. Rate limit FIRST. Validation is cheap but unbounded requests to a
   // public endpoint still cost cycles, and a future refactor that moves
@@ -137,10 +162,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     }
     // Limiter's reserve() only throws RateLimitExceededError (it
     // fail-opens on Upstash outage). Any other throw is unexpected —
-    // let it propagate so the platform's error reporting picks it up;
-    // the route's final catch-all below won't run here because this
-    // block is outside the exchange try/catch by design (rate-limit
-    // failures are infrastructure errors, not sign-in errors).
+    // let it propagate.
     throw err;
   }
 
@@ -153,30 +175,54 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const trimmedCode = (code as string).trim();
 
   // 3. Exchange the code, mapping every failure shape to a known kind.
+  const supabase = await supabaseForRequest();
   let failureKind: ErrorKind | null = null;
   try {
-    const supabase = await supabaseForRequest();
     const { data, error } = await supabase.auth.exchangeCodeForSession(trimmedCode);
     if (error) {
       failureKind = mapSupabaseError(error);
     } else if (!data?.session) {
-      // Unexpected: 200 OK with no session body. Treat as a server error
-      // rather than let a downstream null deref leak through (council
-      // bugs r1).
+      // Unexpected: 200 OK with no session body.
       failureKind = 'server_error';
     }
   } catch (err) {
-    // Final catch-all. A JSON parse failure, TypeError, network drop,
-    // or any non-Error throw lands here and is mapped to server_error.
-    // The route MUST NOT return a 500 (council bugs r1 / r2 / r3).
-    // We log only the error's class name — never the message (which
-    // might echo the code), never the object (which might carry
-    // access/refresh tokens from a partial Supabase response).
+    // Final catch-all. If the throw came FROM the setAll adapter
+    // (cookie_failure halt bubbled through exchangeCodeForSession),
+    // the adapter's failure state will be populated; we detect that
+    // in step 4 below and override this kind to cookie_failure.
     console.error('[auth/callback] unexpected exchange failure', {
       kind: 'server_error',
       errorName: err instanceof Error ? err.name : typeof err,
     });
     failureKind = 'server_error';
+  }
+
+  // 4. cookie_failure precedence. A setAll halt means the browser would
+  // be left with a partial session even if the exchange "succeeded";
+  // the cookie-write failure is the actionable cause and must take
+  // precedence over any generic `server_error` we set in the catch
+  // above. Check regardless of exchange outcome.
+  const cookieFailure = supabase.getCookieWriteFailure();
+  if (cookieFailure) {
+    failureKind = 'cookie_failure';
+    console.error('[auth/callback] sign-in failed', {
+      kind: 'cookie_failure',
+      errorName: cookieFailure.errorName,
+    });
+    try {
+      await rollbackPartialCookies(supabase.getWrittenCookieNames());
+    } catch (err) {
+      // Failure-within-failure-handler. Escalate to 500 by design
+      // rather than swallow. Log only the error class name — never the
+      // cookie names themselves (low leakage risk but keeps the log
+      // shape small for monitoring).
+      console.error('[auth/callback] cookie rollback failed', {
+        kind: 'server_error',
+        errorName: err instanceof Error ? err.name : typeof err,
+      });
+      return new NextResponse('sign-in recovery failed', { status: 500 });
+    }
+    return redirectToAuthError(req, 'cookie_failure');
   }
 
   if (failureKind !== null) {

--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -31,6 +31,11 @@ const CALLBACK_ERROR_MESSAGES: Readonly<Record<string, string>> = {
   token_expired: 'This sign-in link has expired. Request a new one.',
   server_error: 'Could not sign you in right now. Please try again.',
   invalid_request: 'Sign-in link was invalid. Request a new one.',
+  // PR #28 / issue #26: a partial session-cookie write halted mid-
+  // stream. Copy directs the user to request a NEW link rather than
+  // "try again," because the PKCE code was consumed during the halted
+  // exchange — clicking the same link would fail with token_used.
+  cookie_failure: "We couldn't save your sign-in. Request a new link.",
 };
 const GENERIC_CALLBACK_ERROR = 'Sign-in failed. Request a new link.';
 

--- a/apps/web/lib/supabase.test.ts
+++ b/apps/web/lib/supabase.test.ts
@@ -197,6 +197,40 @@ describe('supabaseForRequest — setAll transactional cookie-write', () => {
     expect(errSpy).not.toHaveBeenCalled();
   });
 
+  it('subsequent setAll calls in the same request are no-ops after a halt (council r3 bugs)', async () => {
+    // @supabase/ssr may invoke setAll multiple times in one request
+    // lifecycle (session refresh plus code-exchange, etc.). If the FIRST
+    // call halted transactionally, any later call must be a no-op — we
+    // must not let a second batch land a partial session after the first
+    // already produced a cookie_failure.
+    const attempted: string[] = [];
+    setStub.mockImplementation((name: string) => {
+      attempted.push(name);
+      if (name === 'first') {
+        throw new Error('ECONNRESET — upstream write failed');
+      }
+    });
+    const { supabaseForRequest } = await import('./supabase');
+    const sb = await supabaseForRequest();
+
+    // First call: halts on `first`.
+    capturedAdapter.current!.setAll([
+      { name: 'first', value: 'a', options: {} },
+    ]);
+    expect(sb.getCookieWriteFailure()).toEqual({ errorName: 'Error' });
+    expect(attempted).toEqual(['first']);
+
+    // Second call: MUST be a no-op — no store.set attempts, failure
+    // state unchanged, writtenNames unchanged.
+    capturedAdapter.current!.setAll([
+      { name: 'second', value: 'b', options: {} },
+      { name: 'third', value: 'c', options: {} },
+    ]);
+    expect(attempted).toEqual(['first']); // unchanged
+    expect(sb.getWrittenCookieNames()).toEqual([]);
+    expect(sb.getCookieWriteFailure()).toEqual({ errorName: 'Error' });
+  });
+
   it('successful writes populate getWrittenCookieNames in order', async () => {
     // No throws — everything writes. Names track in call order so the
     // rollback path can delete them without relying on store.getAll().

--- a/apps/web/lib/supabase.test.ts
+++ b/apps/web/lib/supabase.test.ts
@@ -1,14 +1,30 @@
 // Unit coverage for the Next.js cookies() adapter wired into
 // createSupabaseClientForRequest in ./supabase.ts.
 //
-// Council r4 bugs concern: the previous draft swallowed every setAll
-// throw behind `if (process.env.NODE_ENV !== 'production')`, which
-// meant a genuine Route-Handler failure in prod left no trace. The
-// current adapter discriminates on the error message: a Next.js
-// "cookies can only be modified in a Server Action or Route Handler"
-// throw is EXPECTED when a Server Component reads session state and is
-// swallowed silently; anything else is logged via console.error (with
-// cookie names/values omitted) so the bug is visible in production.
+// PR #28 (issue #26) replaces the previous best-effort setAll with a
+// TRANSACTIONAL adapter:
+//
+//   - First unexpected throw halts the loop; subsequent cookies in the
+//     batch are NOT attempted.
+//   - Expected Next.js RSC read-only throws still swallow silently and
+//     DO NOT halt (a Server Component can read session state without
+//     aborting the whole batch; no real write was attempted).
+//   - The adapter no longer logs on its own. Failure surfacing is the
+//     caller's job via the Proxy-exposed accessors:
+//       - supabase.getCookieWriteFailure()  → { errorName } | null
+//       - supabase.getWrittenCookieNames()  → readonly string[]
+//     The /auth/callback route reads these after exchangeCodeForSession
+//     to decide whether to redirect to /auth?error=cookie_failure and
+//     which names to roll back via store.delete().
+//
+// Council r1 on PR #28 non-negotiables enforced here:
+//   - [security] No code / access_token / refresh_token in any log.
+//   - [arch] Method names are getCookieWriteFailure /
+//     getWrittenCookieNames, consistent across interface + Proxy +
+//     tests + docs.
+//   - [security] Proxy passes through unknown / symbol property reads
+//     unchanged via Reflect.get — no blast-radius on unrelated auth
+//     calls.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -21,24 +37,35 @@ type CookieAdapter = {
 
 // Stub next/headers. The test controls what cookies().set() throws.
 const setStub = vi.fn();
+const deleteStub = vi.fn();
 const cookiesStub = {
   getAll: () => [] as Array<{ name: string; value: string }>,
   set: (name: string, value: string, options?: unknown) =>
     setStub(name, value, options),
+  delete: (name: string) => deleteStub(name),
 };
 vi.mock('next/headers', () => ({
   cookies: async () => cookiesStub,
 }));
 
-// Capture the adapter passed into createSupabaseClientForRequest so the
-// test can drive the setAll path directly. The returned "client" object
-// is a no-op stub; none of its methods are exercised.
+// The @llmwiki/db/server mock exposes an instrumented fake client so
+// the test can assert Proxy passthrough. Every property access on the
+// underlying client is logged to `proxyPassthroughCalls`; when the test
+// accesses `someProp` on the Supabase client returned from
+// supabaseForRequest, the Proxy should NOT intercept (only our two
+// accessor names) and the access should reach the fake client.
 const capturedAdapter: { current: CookieAdapter | null } = { current: null };
+const fakeClient: Record<string | symbol, unknown> = {
+  auth: { signInWithOtp: vi.fn(), exchangeCodeForSession: vi.fn() },
+  [Symbol.iterator]: function* () {
+    yield 'underlying-iter';
+  },
+};
 
 vi.mock('@llmwiki/db/server', () => ({
   createSupabaseClientForRequest: (cookies: CookieAdapter) => {
     capturedAdapter.current = cookies;
-    return {};
+    return fakeClient;
   },
   createSupabaseClientForJobs: () => ({}),
   supabaseService: () => ({}),
@@ -49,6 +76,7 @@ let errSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
   vi.resetModules();
   setStub.mockReset();
+  deleteStub.mockReset();
   capturedAdapter.current = null;
   errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 });
@@ -57,8 +85,11 @@ afterEach(() => {
   errSpy.mockRestore();
 });
 
-describe('supabaseForRequest — setAll cookie-write discriminator', () => {
-  it('swallows the Next.js RSC read-only error silently (no log)', async () => {
+// ---------------------------------------------------------------------------
+// setAll transactional behavior
+// ---------------------------------------------------------------------------
+describe('supabaseForRequest — setAll transactional cookie-write', () => {
+  it('swallows the Next.js RSC read-only error silently (no log, no failure state)', async () => {
     setStub.mockImplementation(() => {
       throw new Error(
         'Cookies can only be modified in a Server Action or Route Handler. ' +
@@ -66,113 +97,174 @@ describe('supabaseForRequest — setAll cookie-write discriminator', () => {
       );
     });
     const { supabaseForRequest } = await import('./supabase');
-    await supabaseForRequest();
-    expect(capturedAdapter.current).not.toBeNull();
-    // Drive the adapter directly.
+    const sb = await supabaseForRequest();
     capturedAdapter.current!.setAll([
       { name: 'sb-access-token', value: 'SECRET', options: {} },
     ]);
-    // Expected RSC context → silent swallow. Nothing in console.error.
     expect(errSpy).not.toHaveBeenCalled();
+    expect(sb.getCookieWriteFailure()).toBeNull();
+    expect(sb.getWrittenCookieNames()).toEqual([]);
   });
 
-  it('logs a partial-write summary on an unexpected setAll throw (Route Handler bug)', async () => {
-    setStub.mockImplementation(() => {
-      throw new Error('ECONNRESET — upstream write failed');
-    });
-    const { supabaseForRequest } = await import('./supabase');
-    await supabaseForRequest();
-    capturedAdapter.current!.setAll([
-      { name: 'sb-access-token', value: 'SECRET', options: {} },
-    ]);
-    expect(errSpy).toHaveBeenCalledTimes(1);
-    const [message, context] = errSpy.mock.calls[0] as [string, unknown];
-    expect(message).toMatch(/setAll partial write/i);
-    expect(message).toMatch(/1\/1/);
-    // Regression guard: cookie name + value must NOT appear in the log.
-    const contextString = JSON.stringify(context);
-    expect(message).not.toContain('sb-access-token');
-    expect(message).not.toContain('SECRET');
-    expect(contextString).not.toContain('sb-access-token');
-    expect(contextString).not.toContain('SECRET');
-  });
-
-  it('reports N/M when some writes succeed and some fail (council bugs r5)', async () => {
-    // @supabase/ssr typically sends multiple chunked cookies; a partial
-    // write (1 of 3 fails) must surface as "1/3 cookie writes failed"
-    // so the debugger sees the split state at a glance.
-    setStub.mockImplementation((name: string) => {
-      if (name === 'sb-access-token.1') {
-        throw new Error('ECONNRESET — upstream write failed');
-      }
-    });
-    const { supabaseForRequest } = await import('./supabase');
-    await supabaseForRequest();
-    capturedAdapter.current!.setAll([
-      { name: 'sb-access-token.0', value: 'part0', options: {} },
-      { name: 'sb-access-token.1', value: 'part1', options: {} },
-      { name: 'sb-access-token.2', value: 'part2', options: {} },
-    ]);
-    expect(errSpy).toHaveBeenCalledTimes(1);
-    const [message] = errSpy.mock.calls[0] as [string, unknown];
-    expect(message).toMatch(/1\/3/);
-    expect(message).toMatch(/partial write/i);
-    // Cookie identifiers and values must not appear in the summary.
-    expect(message).not.toContain('sb-access-token');
-    expect(message).not.toContain('part0');
-    expect(message).not.toContain('part1');
-    expect(message).not.toContain('part2');
-  });
-
-  it('continues processing the remaining cookies after one throws', async () => {
-    // Regression: the loop must not halt on a single throw — otherwise
-    // a single flaky cookie would skip the rest of the session chunks.
+  it('continues through multiple RSC throws without halting and without logging', async () => {
+    // Server Component context — every store.set throws the RSC read-only
+    // error. Adapter should attempt every cookie in the batch (caller may
+    // still be reading session state; the fact that no write lands is
+    // fine), emit no log, and report no failure.
     const attempted: string[] = [];
     setStub.mockImplementation((name: string) => {
       attempted.push(name);
-      if (name === 'second')
-        throw new Error(
-          'Cookies can only be modified in a Server Action or Route Handler',
-        );
-    });
-    const { supabaseForRequest } = await import('./supabase');
-    await supabaseForRequest();
-    capturedAdapter.current!.setAll([
-      { name: 'first', value: 'a', options: {} },
-      { name: 'second', value: 'b', options: {} },
-      { name: 'third', value: 'c', options: {} },
-    ]);
-    expect(attempted).toEqual(['first', 'second', 'third']);
-  });
-
-  it('emits no summary log when all throws are the expected RSC case', async () => {
-    // An all-RSC-expected pass should stay silent — the previous
-    // iteration inadvertently logged once per cookie, which would be
-    // noisy in every Server Component render.
-    setStub.mockImplementation(() => {
       throw new Error(
         'Cookies can only be modified in a Server Action or Route Handler',
       );
     });
     const { supabaseForRequest } = await import('./supabase');
-    await supabaseForRequest();
+    const sb = await supabaseForRequest();
     capturedAdapter.current!.setAll([
       { name: 'a', value: '1', options: {} },
       { name: 'b', value: '2', options: {} },
+      { name: 'c', value: '3', options: {} },
     ]);
+    expect(attempted).toEqual(['a', 'b', 'c']);
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(sb.getCookieWriteFailure()).toBeNull();
+    expect(sb.getWrittenCookieNames()).toEqual([]);
+  });
+
+  it('records successful writes and halts on the first UNEXPECTED throw', async () => {
+    // Council bugs r1 on PR #28: transactional. The first unexpected
+    // throw must halt the loop; subsequent cookies in the same batch
+    // are NOT attempted (no partial session lands in the browser).
+    const attempted: string[] = [];
+    setStub.mockImplementation((name: string) => {
+      attempted.push(name);
+      if (name === 'sb-access-token.1') {
+        throw new Error('ECONNRESET — upstream write failed');
+      }
+    });
+    const { supabaseForRequest } = await import('./supabase');
+    const sb = await supabaseForRequest();
+    capturedAdapter.current!.setAll([
+      { name: 'sb-access-token.0', value: 'part0', options: {} },
+      { name: 'sb-access-token.1', value: 'part1', options: {} },
+      { name: 'sb-access-token.2', value: 'part2', options: {} },
+    ]);
+    // Write #3 was NOT attempted (transactional halt).
+    expect(attempted).toEqual(['sb-access-token.0', 'sb-access-token.1']);
+    // Write #1 succeeded and is tracked for rollback.
+    expect(sb.getWrittenCookieNames()).toEqual(['sb-access-token.0']);
+    // Failure is surfaced with the thrown error's class name only.
+    expect(sb.getCookieWriteFailure()).toEqual({ errorName: 'Error' });
+    // Adapter no longer logs on its own — rollback + logging is the
+    // caller's job (kept quiet here so the callback route's log is
+    // the single authoritative signal).
     expect(errSpy).not.toHaveBeenCalled();
   });
 
-  it('treats a non-Error throw as unexpected and logs it', async () => {
+  it('halts on the FIRST unexpected throw even when later cookies would also throw', async () => {
+    // Regression: the halt must not be confused by a second throw
+    // on a subsequent cookie — we should never even ATTEMPT the
+    // subsequent cookie.
+    const attempted: string[] = [];
+    setStub.mockImplementation((name: string) => {
+      attempted.push(name);
+      throw new Error(`${name}-failed`);
+    });
+    const { supabaseForRequest } = await import('./supabase');
+    const sb = await supabaseForRequest();
+    capturedAdapter.current!.setAll([
+      { name: 'first', value: 'a', options: {} },
+      { name: 'second', value: 'b', options: {} },
+      { name: 'third', value: 'c', options: {} },
+    ]);
+    expect(attempted).toEqual(['first']);
+    expect(sb.getWrittenCookieNames()).toEqual([]);
+    expect(sb.getCookieWriteFailure()).toEqual({ errorName: 'Error' });
+  });
+
+  it('treats a non-Error throw as unexpected and records its typeof as errorName', async () => {
     setStub.mockImplementation(() => {
       // eslint-disable-next-line @typescript-eslint/only-throw-error -- test-only
       throw 'bare string rejection';
     });
     const { supabaseForRequest } = await import('./supabase');
-    await supabaseForRequest();
+    const sb = await supabaseForRequest();
     capturedAdapter.current!.setAll([
       { name: 'x', value: 'y', options: {} },
     ]);
-    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(sb.getCookieWriteFailure()).toEqual({ errorName: 'string' });
+    expect(sb.getWrittenCookieNames()).toEqual([]);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('successful writes populate getWrittenCookieNames in order', async () => {
+    // No throws — everything writes. Names track in call order so the
+    // rollback path can delete them without relying on store.getAll().
+    const { supabaseForRequest } = await import('./supabase');
+    const sb = await supabaseForRequest();
+    capturedAdapter.current!.setAll([
+      { name: 'first', value: '1', options: {} },
+      { name: 'second', value: '2', options: {} },
+    ]);
+    expect(sb.getWrittenCookieNames()).toEqual(['first', 'second']);
+    expect(sb.getCookieWriteFailure()).toBeNull();
+  });
+
+  it('getWrittenCookieNames returns a snapshot — mutating it does not affect internal state', async () => {
+    const { supabaseForRequest } = await import('./supabase');
+    const sb = await supabaseForRequest();
+    capturedAdapter.current!.setAll([
+      { name: 'only', value: '1', options: {} },
+    ]);
+    const snapshot = sb.getWrittenCookieNames() as string[];
+    snapshot.push('phantom');
+    expect(sb.getWrittenCookieNames()).toEqual(['only']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Proxy passthrough — council security r1 top-risk #1 guard.
+// ---------------------------------------------------------------------------
+describe('supabaseForRequest — Proxy passthrough', () => {
+  it('passes through access to underlying client properties (auth)', async () => {
+    const { supabaseForRequest } = await import('./supabase');
+    const sb = await supabaseForRequest();
+    // `sb.auth` must reach through to fakeClient.auth, not be intercepted
+    // as one of our sentinel accessor names.
+    expect(sb.auth).toBe(fakeClient.auth);
+  });
+
+  it('returns undefined for unknown string properties (passes through Reflect.get)', async () => {
+    const { supabaseForRequest } = await import('./supabase');
+    const sb = await supabaseForRequest();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    expect((sb as any).__nonexistent__).toBeUndefined();
+  });
+
+  it('passes through symbol property access', async () => {
+    const { supabaseForRequest } = await import('./supabase');
+    const sb = await supabaseForRequest();
+    // The fake client defines Symbol.iterator; Proxy must not eat it.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    expect((sb as any)[Symbol.iterator]).toBe(fakeClient[Symbol.iterator]);
+  });
+
+  it('preserves `in` operator (Reflect.has passthrough) — council nice-to-have', async () => {
+    const { supabaseForRequest } = await import('./supabase');
+    const sb = await supabaseForRequest();
+    expect('auth' in sb).toBe(true);
+    expect('__nonexistent__' in sb).toBe(false);
+    // Our sentinel names exist because Proxy's `get` resolves them; `in`
+    // via default handler uses the target's `has`. We don't need `has`
+    // to report our sentinels — what we need is no REGRESSION in how
+    // `in` answers for real client properties.
+  });
+
+  it('getCookieWriteFailure() is always callable even before any setAll ran', async () => {
+    // Council nice-to-have: early-read of the accessor must not throw.
+    const { supabaseForRequest } = await import('./supabase');
+    const sb = await supabaseForRequest();
+    expect(sb.getCookieWriteFailure()).toBeNull();
+    expect(sb.getWrittenCookieNames()).toEqual([]);
   });
 });

--- a/apps/web/lib/supabase.ts
+++ b/apps/web/lib/supabase.ts
@@ -10,70 +10,118 @@ import {
 } from '@llmwiki/db/server';
 
 /**
+ * State exposed by the Proxy-wrapped Supabase client so the /auth/callback
+ * route can detect a partial session-cookie write and roll back.
+ *
+ * Added in PR #28 (issue #26). See §B of .harness/active_plan.md.
+ *
+ *   - `getCookieWriteFailure()` — returns `{ errorName }` for the first
+ *     unexpected setAll throw that halted the transaction, or `null` if
+ *     no halt occurred in this request's lifetime. `errorName` is the
+ *     thrown error's `.name` (or `typeof` for non-Error throws); the
+ *     value is a class identifier only — never a message, stack, or
+ *     cookie payload. Caller uses it to choose `cookie_failure` over
+ *     `server_error` when both produce failures.
+ *
+ *   - `getWrittenCookieNames()` — returns the names of cookies that
+ *     successfully wrote BEFORE the halt (if any). Returns a fresh
+ *     array copy each call — mutating it does not affect the adapter.
+ *     Caller iterates and `cookies().delete(name)` each so the browser
+ *     is not left with a partial session-cookie set.
+ */
+export interface CookieWriteState {
+  getCookieWriteFailure(): { errorName: string } | null;
+  getWrittenCookieNames(): readonly string[];
+}
+
+type SupabaseClientForRequest = ReturnType<typeof createSupabaseClientForRequest>;
+
+/**
  * Request-scoped Supabase client wired to Next.js's `cookies()` API.
  * Reads AND writes cookies — so this is the correct factory for Route
  * Handlers, Server Actions, AND Server Components (reads only).
  *
- * For PKCE sign-in: /auth/callback hits exchangeCodeForSession, which
- * writes the session cookie via the setAll callback below. Before PR
- * #22 this path used a read-only client and the session landed on the
- * floor. See packages/db/src/server.ts for the factory split rationale.
+ * Returns the Supabase client wrapped in a Proxy that surfaces
+ * cookie-write transaction state (see {@link CookieWriteState}).
+ * The Proxy intercepts ONLY the two sentinel accessor names — every
+ * other property / symbol read flows through `Reflect.get` unchanged,
+ * so the wrapper is transparent to consumers that only need the
+ * standard Supabase surface.
  *
- * In a Server Component, Next.js forbids cookie mutation — `store.set`
- * throws. That's expected when a component reads session state via this
- * client, so we catch the throw and debug-log rather than propagate.
+ * ### Transactional setAll
+ *
+ * @supabase/ssr's PKCE flow calls `setAll([...])` with multiple chunked
+ * cookies in a single invocation. Before PR #28 we tried every cookie
+ * and summary-logged partial failures. That was wrong for auth: a
+ * partial session-cookie write lands a broken session in the browser
+ * and the user experiences a silent login failure after clicking a
+ * valid link.
+ *
+ * The current adapter halts on the first UNEXPECTED throw. The expected
+ * Next.js "cookies can only be modified in a Server Action or Route
+ * Handler" throw from Server Components still swallows silently and
+ * does NOT halt (no write was actually attempted; the SC may still
+ * want to read session state). Anything else records a failure and
+ * stops the loop — the caller (route handler) reads the failure and
+ * rolls back.
+ *
+ * The adapter NEVER logs on its own. Logging lives where the rollback
+ * is decided — the route handler knows the error kind and writes a
+ * single authoritative line. Keeping the adapter quiet avoids
+ * double-logging and keeps the log set grep-stable for monitoring.
  */
-export async function supabaseForRequest() {
+export async function supabaseForRequest(): Promise<
+  SupabaseClientForRequest & CookieWriteState
+> {
   const store = await cookies();
-  return createSupabaseClientForRequest({
+
+  let failure: { errorName: string } | null = null;
+  const writtenNames: string[] = [];
+
+  const client = createSupabaseClientForRequest({
     getAll() {
       return store.getAll().map(({ name, value }) => ({ name, value }));
     },
     setAll(cookiesToSet) {
-      // Discriminate two failure modes per write (council bugs r4) AND
-      // accumulate unexpected failures so we can surface one partial-
-      // write summary at the end (council bugs r5).
-      //
-      //   1. Server Component context — Next.js forbids cookie mutation
-      //      from render. The thrown error's message contains "Cookies
-      //      can only be modified in a Server Action or Route Handler"
-      //      (or minor variants across Next versions). Expected when an
-      //      RSC reads session state via this client; swallow silently.
-      //
-      //   2. Anything else — a Route Handler or Server Action where the
-      //      write SHOULD have succeeded but didn't. @supabase/ssr
-      //      typically sends multiple chunked cookies in one setAll
-      //      call; if one fails but others succeed the user is left
-      //      with a partial session. Continuing the loop is right
-      //      (best-effort: maybe one chunk was transient), but a
-      //      post-loop summary log makes the partial-write signal
-      //      explicit so a future debug session doesn't miss it.
-      const unexpectedErrorNames: string[] = [];
+      // Skip entirely if a prior setAll call in this request already
+      // halted the transaction — @supabase/ssr can batch multiple
+      // setAll invocations, and we must not accept writes after a halt.
+      if (failure) return;
+
       for (const { name, value, options } of cookiesToSet) {
         try {
           store.set(name, value, options);
+          writtenNames.push(name);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           const isExpectedRscContext =
             /cookies.*modif|server\s*action|route\s*handler/i.test(msg);
-          if (isExpectedRscContext) continue;
-          unexpectedErrorNames.push(
-            err instanceof Error ? err.name : typeof err,
-          );
+          if (isExpectedRscContext) {
+            // Server Component context — writes are forbidden by
+            // Next.js. Not an error; skip this name and continue so
+            // the SC can finish reading session state.
+            continue;
+          }
+          // Unexpected failure. Record (first wins) and halt the loop.
+          // Subsequent cookies in this batch are NOT attempted — a
+          // partial session-cookie set is the very failure mode this
+          // halt is closing.
+          failure = {
+            errorName: err instanceof Error ? err.name : typeof err,
+          };
+          break;
         }
-      }
-      if (unexpectedErrorNames.length > 0) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `supabase: setAll partial write — ${unexpectedErrorNames.length}/` +
-            `${cookiesToSet.length} cookie writes failed in a write-capable ` +
-            'context. Session may be inconsistent. Cookie names and values ' +
-            'omitted to avoid leakage.',
-          { errorNames: unexpectedErrorNames },
-        );
       }
     },
   });
+
+  return new Proxy(client, {
+    get(target, prop, receiver) {
+      if (prop === 'getCookieWriteFailure') return () => failure;
+      if (prop === 'getWrittenCookieNames') return () => [...writtenNames];
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as SupabaseClientForRequest & CookieWriteState;
 }
 
 /**

--- a/apps/web/tests/unit/auth-callback-route.test.ts
+++ b/apps/web/tests/unit/auth-callback-route.test.ts
@@ -31,9 +31,38 @@ import { NextRequest } from 'next/server';
 
 const exchangeCodeForSession = vi.fn();
 
+// Cookie-write transaction state controllable per-test. The route reads
+// these accessors after exchangeCodeForSession to decide whether a
+// setAll failure halted the session-cookie write and partial cookies
+// need rolling back.
+const cookieWriteFailure: { current: { errorName: string } | null } = {
+  current: null,
+};
+const writtenCookieNames: { current: readonly string[] } = { current: [] };
+
 vi.mock('../../lib/supabase', () => ({
   supabaseForRequest: () => ({
     auth: { exchangeCodeForSession },
+    getCookieWriteFailure: () => cookieWriteFailure.current,
+    getWrittenCookieNames: () => writtenCookieNames.current,
+  }),
+}));
+
+// next/headers cookies() stub. The route's cookie_failure rollback path
+// imports `cookies` from 'next/headers' and calls `.delete(name)` on each
+// name returned by getWrittenCookieNames. Individual tests control the
+// `.delete` behavior (including throwing to drive the rollback-fail
+// edge case). `.set` is unused by the route itself (writes go through
+// the Supabase adapter) — kept as a no-op so any accidental call is
+// observable via the spy.
+const cookieDeleteStub = vi.fn();
+const cookieSetStub = vi.fn();
+vi.mock('next/headers', () => ({
+  cookies: async () => ({
+    getAll: () => [] as Array<{ name: string; value: string }>,
+    set: (name: string, value: string, options?: unknown) =>
+      cookieSetStub(name, value, options),
+    delete: (name: string) => cookieDeleteStub(name),
   }),
 }));
 
@@ -92,6 +121,10 @@ beforeEach(() => {
   exchangeCodeForSession.mockReset();
   reserveSpy.mockReset();
   reserveSpy.mockResolvedValue(undefined); // default: allow through
+  cookieWriteFailure.current = null;
+  writtenCookieNames.current = [];
+  cookieDeleteStub.mockReset();
+  cookieSetStub.mockReset();
   errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 });
 
@@ -516,4 +549,149 @@ describe('GET /auth/callback — no token leakage in logs', () => {
       assertNoTokenLeaks(errorSpy, VALID_CODE);
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Issue #26 / PR #28: cookie_failure rollback path.
+//
+// When @supabase/ssr's setAll adapter halts mid-stream (first unexpected
+// throw), the route must:
+//   (a) detect the halt via supabase.getCookieWriteFailure(),
+//   (b) delete any cookies that WERE written before the halt,
+//   (c) 307 to /auth?error=cookie_failure,
+//   (d) never leak a token to logs.
+// ---------------------------------------------------------------------------
+describe('GET /auth/callback — cookie_failure rollback (issue #26)', () => {
+  it('detects a cookie-write halt after a successful exchange and redirects with error=cookie_failure', async () => {
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    cookieWriteFailure.current = { errorName: 'Error' };
+    writtenCookieNames.current = ['sb-access-token.0'];
+
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(res.status).toBe(307);
+    const loc = new URL(res.headers.get('location') ?? '');
+    expect(loc.pathname).toBe('/auth');
+    expect(loc.searchParams.get('error')).toBe('cookie_failure');
+    assertNoTokenLeaks(errorSpy, VALID_CODE);
+  });
+
+  it('deletes every partially-written cookie name during rollback', async () => {
+    // The adapter tracks writes that succeeded BEFORE the halt. The
+    // route must call store.delete(name) for each so the user does not
+    // leave the /auth/callback request with a partial session cookie
+    // hanging around.
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    cookieWriteFailure.current = { errorName: 'Error' };
+    writtenCookieNames.current = ['sb-access-token.0', 'sb-refresh-token'];
+
+    const { GET } = await import('../../app/auth/callback/route');
+    await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(cookieDeleteStub).toHaveBeenCalledTimes(2);
+    expect(cookieDeleteStub).toHaveBeenCalledWith('sb-access-token.0');
+    expect(cookieDeleteStub).toHaveBeenCalledWith('sb-refresh-token');
+  });
+
+  it('no partial-cookie deletion when nothing was written before the halt', async () => {
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    cookieWriteFailure.current = { errorName: 'TypeError' };
+    writtenCookieNames.current = [];
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(cookieDeleteStub).not.toHaveBeenCalled();
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'cookie_failure',
+    );
+  });
+
+  it('cookie_failure takes precedence over server_error when exchange throws a setAll-origin error', async () => {
+    // A setAll throw bubbles up THROUGH exchangeCodeForSession as a
+    // generic Error. The route's existing catch-all would map it to
+    // server_error. Non-negotiable: cookie_failure wins, because the
+    // cookie-write failure is the proximate, actionable cause.
+    exchangeCodeForSession.mockRejectedValueOnce(new Error('setAll halted'));
+    cookieWriteFailure.current = { errorName: 'Error' };
+    writtenCookieNames.current = ['sb-access-token.0'];
+
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'cookie_failure',
+    );
+    expect(cookieDeleteStub).toHaveBeenCalledWith('sb-access-token.0');
+    assertNoTokenLeaks(errorSpy, VALID_CODE);
+  });
+
+  it('rollback-itself-fails escalates to 500 (documented trade-off, council bugs r1)', async () => {
+    // Failure-within-a-failure-handler. cookies().delete(name) throws,
+    // e.g. a future Next.js version adding a guard. The route allows
+    // the throw to escalate to a 500 rather than silently swallowing —
+    // silent swallow would hide the bug. 500 is greppable.
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    cookieWriteFailure.current = { errorName: 'Error' };
+    writtenCookieNames.current = ['sb-access-token.0'];
+    cookieDeleteStub.mockImplementation(() => {
+      throw new Error('cookies() store is frozen');
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const res = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(res.status).toBe(500);
+    assertNoTokenLeaks(errorSpy, VALID_CODE);
+  });
+
+  it('does not leak tokens in the cookie_failure log line', async () => {
+    // Regression guard on the new branch — keep the token-leak invariant.
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    cookieWriteFailure.current = { errorName: 'Error' };
+    writtenCookieNames.current = ['sb-access-token.0'];
+    const { GET } = await import('../../app/auth/callback/route');
+    await GET(makeReq(`?code=${VALID_CODE}`));
+    assertNoTokenLeaks(errorSpy, VALID_CODE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Double-click / mail-client prefetch: two sequential GETs with the same
+// code. First succeeds; second hits a consumed code and maps to token_used.
+// ---------------------------------------------------------------------------
+describe('GET /auth/callback — double-click / prefetch (council r1 security must-do)', () => {
+  it('maps a second GET with the consumed code to ?error=token_used', async () => {
+    // First call: Supabase returns a session; route redirects to /.
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: { access_token: 'REDACTED' } },
+      error: null,
+    });
+    // Second call: Supabase reports the code was already consumed.
+    exchangeCodeForSession.mockResolvedValueOnce({
+      data: { session: null },
+      error: { message: 'Code already used; request a new magic link', status: 400 },
+    });
+    const { GET } = await import('../../app/auth/callback/route');
+    const first = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(new URL(first.headers.get('location') ?? '').pathname).toBe('/');
+
+    const second = await GET(makeReq(`?code=${VALID_CODE}`));
+    expect(second.status).toBe(307);
+    expect(new URL(second.headers.get('location') ?? '').searchParams.get('error')).toBe(
+      'token_used',
+    );
+    expect(exchangeCodeForSession).toHaveBeenCalledTimes(2);
+    assertNoTokenLeaks(errorSpy, VALID_CODE);
+  });
 });

--- a/packages/lib/ratelimit/src/index.test.ts
+++ b/packages/lib/ratelimit/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   makeTokenBudgetLimiter,
   makeIngestEventLimiter,
@@ -122,6 +122,35 @@ describe('magic link limiter', () => {
 });
 
 describe('auth callback limiter (tier D)', () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  /**
+   * Stringify a value for substring scanning. Objects via JSON; anything
+   * that fails to stringify falls back to String(). Used to assert that
+   * a raw IP is NEVER anywhere in a console.error argument — not as
+   * object key, value, nested property, or message.
+   */
+  function stringifyArg(x: unknown): string {
+    try {
+      return typeof x === 'string' ? x : JSON.stringify(x);
+    } catch {
+      return String(x);
+    }
+  }
+
+  /** Concatenation of every console.error argument across every call. */
+  function allErrArgs(spy: ReturnType<typeof vi.spyOn>): string {
+    return spy.mock.calls.flat().map(stringifyArg).join('\n');
+  }
+
   it('AUTH_CALLBACK_PER_IP_PER_MINUTE is 20', () => {
     expect(AUTH_CALLBACK_PER_IP_PER_MINUTE).toBe(20);
   });
@@ -135,6 +164,95 @@ describe('auth callback limiter (tier D)', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
     const lim = makeAuthCallbackLimiter({ redis: redis as any });
     await expect(lim.reserve('1.2.3.4')).resolves.toBeUndefined();
+  });
+
+  // ===== Issue #26 / PR #28 — fail-open alerting =========================
+
+  it('emits a structured alert on fail-open so monitoring can page', async () => {
+    // Council security r2 on PR #25: "A silently disabled control is
+    // not a control." The fail-open branch MUST log a monitor-greppable
+    // record with stable keys so a log drain + alerting rule can fire
+    // when Upstash degrades.
+    const redis = { eval: async () => { throw new Error('network'); } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    const lim = makeAuthCallbackLimiter({ redis: redis as any });
+    await lim.reserve('203.0.113.9');
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    const [message, context] = errSpy.mock.calls[0] as [string, unknown];
+    expect(message).toContain('fail-open');
+    expect(context).toMatchObject({
+      alert: true,
+      tier: 'auth_callback_ip',
+    });
+    // ip_bucket is a short prefix, not the full IP.
+    const ipBucket = (context as { ip_bucket?: unknown }).ip_bucket;
+    expect(typeof ipBucket).toBe('string');
+    expect((ipBucket as string).length).toBeLessThanOrEqual(3);
+  });
+
+  it('fail-open log NEVER contains the raw IP string anywhere in any argument', async () => {
+    // Council security r1 must-do: stringify EVERY console.error argument
+    // and assert the raw ip is not a substring anywhere — not just
+    // "not passed directly" but "not reachable by any grep."
+    const rawIp = '203.0.113.9';
+    const redis = { eval: async () => { throw new Error('network'); } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    const lim = makeAuthCallbackLimiter({ redis: redis as any });
+    await lim.reserve(rawIp);
+    expect(allErrArgs(errSpy)).not.toContain(rawIp);
+  });
+
+  it('fail-open with undefined ip logs ip_bucket="unknown" without TypeError', async () => {
+    // Council bugs r1: if ip is missing, `ip.slice(0,3)` would TypeError
+    // and swallow the very alert the plan adds. Null-safe bucketing
+    // falls back to the literal string "unknown".
+    const redis = { eval: async () => { throw new Error('network'); } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    const lim = makeAuthCallbackLimiter({ redis: redis as any });
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+      lim.reserve(undefined as any),
+    ).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    const [, context] = errSpy.mock.calls[0] as [string, unknown];
+    expect((context as { ip_bucket?: unknown }).ip_bucket).toBe('unknown');
+  });
+
+  it('fail-open with null ip logs ip_bucket="unknown" without TypeError', async () => {
+    const redis = { eval: async () => { throw new Error('network'); } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    const lim = makeAuthCallbackLimiter({ redis: redis as any });
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+      lim.reserve(null as any),
+    ).resolves.toBeUndefined();
+    const [, context] = errSpy.mock.calls[0] as [string, unknown];
+    expect((context as { ip_bucket?: unknown }).ip_bucket).toBe('unknown');
+  });
+
+  it('fail-open with empty-string ip logs ip_bucket="unknown"', async () => {
+    const redis = { eval: async () => { throw new Error('network'); } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    const lim = makeAuthCallbackLimiter({ redis: redis as any });
+    await expect(lim.reserve('')).resolves.toBeUndefined();
+    const [, context] = errSpy.mock.calls[0] as [string, unknown];
+    expect((context as { ip_bucket?: unknown }).ip_bucket).toBe('unknown');
+  });
+
+  it('fail-open log includes a non-empty errorName (class identifier)', async () => {
+    // @upstash/ratelimit wraps the underlying redis throw before it
+    // reaches our catch, so we don't assert the exact class — the
+    // contract is "some class identifier string," stable enough for
+    // monitoring to distinguish "rate limiter is unhappy" from "rate
+    // limiter is quiet." Payload / message is NOT in the log.
+    const redis = { eval: async () => { throw new Error('redis down'); } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    const lim = makeAuthCallbackLimiter({ redis: redis as any });
+    await lim.reserve('198.51.100.1');
+    const [, context] = errSpy.mock.calls[0] as [string, unknown];
+    const errorName = (context as { errorName?: unknown }).errorName;
+    expect(typeof errorName).toBe('string');
+    expect((errorName as string).length).toBeGreaterThan(0);
   });
 
   it('accepts auth_callback_ip as a RateLimitExceededError kind', () => {

--- a/packages/lib/ratelimit/src/index.ts
+++ b/packages/lib/ratelimit/src/index.ts
@@ -171,16 +171,49 @@ export function makeAuthCallbackLimiter(deps: RateLimitDeps = {}) {
    * Check-and-decrement the per-IP callback counter.
    *
    *   - Throws RateLimitExceededError('auth_callback_ip') if over the limit.
-   *   - FAIL-OPEN on Upstash unreachable: resolves without reserving.
-   *     Intentional: a transient Redis outage must not deny a legit
-   *     user's link-click. Supabase's own project rate limits provide
-   *     the deeper backstop against sustained abuse.
+   *   - FAIL-OPEN on Upstash unreachable: resolves without reserving, AND
+   *     emits a structured `alert: true` log so monitoring can page.
+   *     Intentional fail-open: a transient Redis outage must not deny a
+   *     legit user's link-click. Silent fail-open is worse than no
+   *     limiter — a disabled control with no visibility is invisibly
+   *     absent. The alert log shape is the stable grep contract;
+   *     see README.md §Monitoring.
+   *
+   * ### Monitor grep contract (STABLE)
+   *
+   * ```
+   * [rate-limit] fail-open triggered { alert: true, tier: 'auth_callback_ip', errorName, ip_bucket }
+   * ```
+   *
+   * - `alert: true` — monitor trigger flag
+   * - `tier: 'auth_callback_ip'` — which limiter fired
+   * - `errorName: string` — the thrown error's `.name` (or typeof for
+   *   non-Error throws) — a class identifier only, no payload
+   * - `ip_bucket: string` — 3-character prefix of the IP for coarse
+   *   locality, or the literal `'unknown'` if ip is missing. NEVER
+   *   the full IP.
+   *
+   * Do NOT rename these keys without a coordinated monitoring-config
+   * change.
    */
-  async function reserve(ip: string): Promise<void> {
+  async function reserve(ip: string | null | undefined): Promise<void> {
     let result: Awaited<ReturnType<typeof limiter.limit>>;
     try {
-      result = await limiter.limit(ip);
-    } catch {
+      result = await limiter.limit(ip ?? 'no-xff');
+    } catch (err) {
+      // Null-safe ip_bucket. Council bugs r1 on PR #28: `ip.slice(0,3)`
+      // on a missing ip would TypeError and swallow the alert entirely —
+      // re-introducing the very silent-fail-open gap this branch is
+      // adding visibility to.
+      const ip_bucket =
+        typeof ip === 'string' && ip.length > 0 ? ip.slice(0, 3) : 'unknown';
+      // eslint-disable-next-line no-console
+      console.error('[rate-limit] fail-open triggered', {
+        alert: true,
+        tier: 'auth_callback_ip',
+        errorName: err instanceof Error ? err.name : typeof err,
+        ip_bucket,
+      });
       return; // fail-OPEN; see docstring for rationale
     }
     if (!result.success) {


### PR DESCRIPTION
## Summary

Plan-only PR for issue #26 (auth hardening: transactional `setAll` + rate-limit fail-open alerting). Implementation lands as follow-up commits on this same PR after council r1 + human approval per `CLAUDE.md` prime directive.

## Plan highlights

- **Transactional `setAll`** in `apps/web/lib/supabase.ts` via Proxy-wrapped client with `getCookieWriteFailure()` + `getCookieWriteNames()` accessors; first unexpected throw halts the loop and subsequent writes are NOT attempted.
- **Rollback path** in `/auth/callback/route.ts`: iterate written cookie names and `store.delete` each, then 307 to `/auth?error=cookie_failure`. Takes precedence over `server_error` when a `setAll` throw bubbles through `exchangeCodeForSession`.
- **New `cookie_failure` allowlist entry** on `/auth/page.tsx`; reuses existing `aria-live="assertive"` region and `text-danger` styling (WCAG AA preserved). XSS-safe (allowlist key lookup only).
- **Fail-open alerting log** in `packages/lib/ratelimit/src/index.ts` → stable `{ alert: true, tier: 'auth_callback_ip', errorName, ip_bucket }` shape documented as monitor-grep contract. No raw IPs.
- **Double-click / prefetch** (Outlook Safe Links etc.) explicitly covered: second GET with consumed code → `token_used`.
- **Decision documented, NOT added:** `server_error` remains the mapping for 200-OK-with-null-session; splitting into `exchange_failed` adds a user-facing kind with identical copy for no user benefit (council r2 open question).

## Test plan

- [ ] `apps/web/lib/supabase.test.ts` — extend with transactional halt + accessor tests
- [ ] `apps/web/tests/unit/auth-callback-route.test.ts` — `cookie_failure` branch, partial-rollback, double-click → `token_used`, rollback-precedence-over-server_error
- [ ] `packages/lib/ratelimit/src/index.test.ts` — fail-open log shape + no-raw-IP + happy / over-limit regressions
- [ ] Token-leak spy preserved across all new branches (never `code` / `access_token` / `refresh_token` in `console.error`)
- [ ] `pnpm lint` + `pnpm typecheck` + `pnpm test` green locally
- [ ] Manual smoke: valid sign-in still 302 → `/`; induced cookie failure → `/auth?error=cookie_failure`

## Council

Automatic via `.github/workflows/council.yml` on PR open. Plan is council-required (auth surface). No `[skip council]`.

Refs: #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)