### PR TITLE
feat(srs): FSRS rating + scheduling on /review (closes the SRS loop)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -31,6 +31,12 @@ paths = [
   '''\.harness/last_council\.md''',
   '''\.harness/active_plan\.md''',
   '''\.harness/learnings\.md''',
+  # pgTAP tests use synthetic JWT-claim strings — e.g.,
+  # `set local request.jwt.claims = '{"sub":"<uuid>","role":"authenticated"}'`
+  # — to simulate authenticated users. The generic-api-key rule reads
+  # them as JWT-shaped tokens. Test fixtures only; real secrets would
+  # never intentionally land in pgTAP.
+  '''supabase/tests/.*\.sql''',
 ]
 # Placeholder strings used in examples and docs.
 regexes = [

--- a/.harness/active_plan.md
+++ b/.harness/active_plan.md
@@ -1,8 +1,8 @@
 # Plan: FSRS rating + scheduling on /review (closes the SRS loop)
 
-**Status:** draft, awaiting council + human approval.
+**Status:** r2 — folded council r1 REVISE 6/9/3/10/10/3 (8 substantive non-negotiables: idempotency key, optimistic concurrency, Zod validation on `fsrs_state`, per-user rate limit, pinned `ts-fsrs` version, RLS-negative test in `actions.test.ts`, focus management on auto-advance, down-migration). Awaiting council r2 + human approval.
 **Branch:** `claude/fsrs-scoring`.
-**Scope:** rating UI on `/review` (Again/Hard/Good/Easy) + server action that runs the FSRS algorithm + persists state. New runtime dep (`ts-fsrs`). New typed wrappers around `srs_cards.fsrs_state` and `review_history.{prev,next}_state`. **No `[skip council]`** — new external lib + auth-gated mutation surface + the kind of state-machine math council should scrutinize.
+**Scope:** rating UI on `/review` (Again/Hard/Good/Easy) + server action that runs the FSRS algorithm + persists state atomically with idempotency + optimistic concurrency. New runtime dep (`ts-fsrs` pinned exact version). New typed wrappers around `srs_cards.fsrs_state` and `review_history.{prev,next}_state`. New per-user rate-limit Tier (E). **No `[skip council]`** — new external lib + auth-gated mutation surface + the kind of state-machine math council should scrutinize.
 
 ## Problem
 
@@ -24,20 +24,30 @@ The /review query stays unchanged in this PR — still `order by created_at desc
 
 **In:**
 
-- `apps/web/package.json` — add `ts-fsrs` (pinned, exact version). Runtime dep.
-- `packages/lib/srs/` — new tiny package wrapping `ts-fsrs` with our domain types + a single `nextState(currentState, rating)` pure function. Reasons for a wrapper package:
+- `packages/lib/srs/package.json` — pin `ts-fsrs` to an exact version (no `^` / `~`). Runtime dep declared in this leaf package only; not in `apps/web/package.json` (the app imports the wrapper, not the lib directly). Pinning is a council r1 security non-negotiable: an automatic minor bump could change scheduling intervals; bumps require a council round.
+- `packages/lib/srs/` — new tiny package wrapping `ts-fsrs` with our domain types + Zod schema for `FsrsCardState` + a single `nextState(currentState, rating)` pure function. Reasons for a wrapper package:
   1. Keeps `ts-fsrs` import surface narrow — only one file imports it.
   2. Lets us swap the underlying lib later without touching app code.
   3. Provides a single test-target for the algorithm contract (failure-mode tests live here per the new rebuttal-protocol rule).
-- `apps/web/app/review/actions.ts` — new server action `submitReview(cardId, rating)`. RLS-scoped via `supabaseForRequest`; runs `nextState`; persists via a Postgres function (`fn_review_card`) called via Supabase RPC for atomicity.
-- `supabase/migrations/20260424000001_fn_review_card.sql` — new SQL function `fn_review_card(p_card_id uuid, p_rating smallint, p_next_state jsonb, p_due_at timestamptz, p_prev_state jsonb)` that updates `srs_cards.fsrs_state` + `due_at` AND inserts `review_history` in a single transaction. RLS via `security invoker` (so the caller's `auth.uid()` is checked against `srs_cards_own` + `review_history_own`).
-- `apps/web/app/review/ReviewDeck.tsx` — extend with rating buttons (4 buttons after answer reveal, hidden before reveal); wire to the server action; on success, call existing `handleNext`.
-- `apps/web/lib/i18n.ts` — 6 new keys: `review.rating.again`, `review.rating.hard`, `review.rating.good`, `review.rating.easy`, `review.rating_error`, `review.rating_pending`.
+  4. Hosts the `FsrsCardStateSchema` Zod parser so any DB read of `fsrs_state` validates at the boundary (council r1 bugs fold).
+- `apps/web/app/review/actions.ts` — new server action `submitReview(cardId, rating, idempotencyKey)`. RLS-scoped via `supabaseForRequest`; runs `nextState` (with Zod-parsed prev state); persists via a Postgres function (`fn_review_card`) called via Supabase RPC for atomicity + optimistic concurrency. Per-user rate-limited via the new Tier E limiter.
+- `packages/lib/ratelimit/src/index.ts` — add **Tier E: rating submits, 30 / user / minute**. Mirrors Tier B's per-user keying + sliding window. Rationale (council r1 security non-negotiable): mutation endpoints need rate-limit per CLAUDE.md non-negotiables; 30/min is well above realistic user behavior (a serious study session is ~5–10 cards/min) and well below abuse rates.
+- `supabase/migrations/20260424000001_review_history_idempotency.sql` — new column `review_history.idempotency_key text not null` + `unique (user_id, idempotency_key)` constraint. Council r1 bugs non-negotiable: closes the retry-after-network-drop double-apply gap.
+- `supabase/migrations/20260424000002_fn_review_card.sql` — new SQL function `fn_review_card(p_card_id uuid, p_rating smallint, p_next_state jsonb, p_due_at timestamptz, p_prev_state jsonb, p_idempotency_key text)` that:
+  - Inserts into `review_history` with `on conflict (user_id, idempotency_key) do nothing returning id` — idempotent retry.
+  - If the insert was a no-op (replay): returns success without touching `srs_cards`.
+  - Else: updates `srs_cards.fsrs_state` + `due_at` with `WHERE id = p_card_id AND fsrs_state = p_prev_state` (optimistic concurrency — council r1 bugs non-negotiable). If 0 rows updated, raises `40001` (serialization failure) so the server action can return `concurrent_update`.
+  - All in a single transaction. RLS via `security invoker`.
+- `supabase/migrations/20260424000003_fn_review_card_down.sql` — companion down-migration: `drop function public.fn_review_card`, `alter table public.review_history drop constraint review_history_idempotency_unique, drop column idempotency_key`. Council r1 arch fold.
+- `apps/web/app/review/ReviewDeck.tsx` — extend with rating buttons (4 buttons after answer reveal, hidden before reveal); generates an `idempotencyKey = crypto.randomUUID()` per rating click; wires to the server action; on success, calls existing `handleNext`. Auto-advance moves keyboard focus to the new card heading via the existing `headingRef` + `useEffect` pattern from PR #42 — verified by extending the existing focus-management test (council r1 a11y non-negotiable).
+- `apps/web/lib/i18n.ts` — 7 new keys: `review.rating.again`, `review.rating.hard`, `review.rating.good`, `review.rating.easy`, `review.rating_error`, `review.rating_pending`, `review.rating_rate_limit_error` (new for the rate-limit failure path).
+- `apps/web/tailwind.config.ts` (or `globals.css`) — verify `bg-warning` + `text-brand-900` pair passes WCAG AA 3:1 for UI components. Council r1 a11y fold; if the existing palette fails, the "Hard" button gets a darker amber shade documented in the same diff. The existing `axe-core` smoke test at `apps/web/tests/a11y/smoke.spec.ts` will be extended to include the rating cluster's static markup.
 - Tests:
-  - `packages/lib/srs/src/index.test.ts` — algorithm contract, failure-mode coverage (see §Tests).
-  - `apps/web/app/review/actions.test.ts` — server-action behavior, RLS enforcement, transaction atomicity stub, PII-safe logging, rating validation.
-  - `apps/web/components/ReviewDeck.test.tsx` — rating buttons disabled before reveal, enabled after, fire on click, advance card on success.
-  - `supabase/tests/fn_review_card.sql` — pgTAP test for the SQL function (acknowledged-flaky per #7; written but not load-bearing for the rebuttal protocol).
+  - `packages/lib/srs/src/index.test.ts` — algorithm contract, Zod parse happy/sad paths, failure-mode coverage (see §Tests).
+  - `apps/web/app/review/actions.test.ts` — server-action behavior, **explicit RLS-blocked test** (council r1 security non-negotiable: live in this consistently-passing suite, not just pgTAP), idempotency replay test, concurrent-update / `40001` test, rate-limit-exceeded test, Zod-malformed-state test, PII-safe logging negative-sentinel.
+  - `apps/web/components/ReviewDeck.test.tsx` — rating buttons disabled before reveal, enabled after, fire on click with `idempotencyKey` passed, advance card on success, focus moves to next card heading after auto-advance, rate-limit error renders distinct copy.
+  - `packages/lib/ratelimit/src/index.test.ts` — extended with Tier E happy-path + boundary cases (allow at limit, deny at limit+1).
+  - `supabase/tests/fn_review_card.sql` — pgTAP test for the SQL function (acknowledged-flaky per #7; written but **NOT** load-bearing for the rebuttal protocol per the new CLAUDE.md "consistently passing" rule).
 
 **Out (explicit):**
 
@@ -65,6 +75,7 @@ The new SQL function `fn_review_card` runs as `security invoker` so `auth.uid()`
 
 ```ts
 // packages/lib/srs/src/index.ts
+import { z } from 'zod';
 import { FSRS, generatorParameters, Rating, type Card } from 'ts-fsrs';
 
 export const RATING_AGAIN = 1;
@@ -81,6 +92,11 @@ export function isValidRating(r: unknown): r is RatingValue {
  * Our wire shape for srs_cards.fsrs_state and review_history.{prev,next}_state.
  * Matches ts-fsrs's Card serialization 1:1; explicit interface so a future
  * lib swap can target a stable contract.
+ *
+ * Council r1 bugs fold: the Zod schema below is the runtime validator. Any
+ * read of fsrs_state from the DB MUST go through `parseFsrsState` before
+ * passing to `nextState` — protects against malformed JSONB from a past bug,
+ * manual DB edit, or schema drift.
  */
 export interface FsrsCardState {
   due: string;             // ISO timestamp
@@ -92,6 +108,35 @@ export interface FsrsCardState {
   lapses: number;
   state: 0 | 1 | 2 | 3;    // 0=new, 1=learning, 2=review, 3=relearning
   last_review?: string;    // ISO timestamp; undefined for never-reviewed
+}
+
+export const FsrsCardStateSchema = z.object({
+  due: z.string().datetime({ offset: true }),
+  stability: z.number().finite().nonnegative(),
+  difficulty: z.number().finite(),
+  elapsed_days: z.number().finite().nonnegative(),
+  scheduled_days: z.number().finite().nonnegative(),
+  reps: z.number().int().nonnegative(),
+  lapses: z.number().int().nonnegative(),
+  state: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]),
+  last_review: z.string().datetime({ offset: true }).optional(),
+});
+
+/**
+ * Parse a value (typically `srs_cards.fsrs_state` from a Supabase select)
+ * into a typed `FsrsCardState`. Returns `null` for the empty-state sentinel
+ * `{}` (a never-reviewed card) so the caller can branch to `emptyFsrsState()`.
+ *
+ * Throws `ZodError` on a non-empty malformed shape so the caller can decide
+ * whether to fail loud (server action returns persist_failed) or fall back
+ * to a fresh empty state. The decision is intentionally NOT made here —
+ * this is the validator, not the policy.
+ */
+export function parseFsrsState(raw: unknown): FsrsCardState | null {
+  if (raw && typeof raw === 'object' && Object.keys(raw).length === 0) {
+    return null;  // {} sentinel = never-reviewed
+  }
+  return FsrsCardStateSchema.parse(raw);
 }
 
 /**
@@ -166,12 +211,42 @@ export function nextState(
 
 **Why `ts-fsrs` over rolling our own:** the FSRS-5 algorithm has subtle math (logarithmic stability decay, retrievability formulas, difficulty drift). `ts-fsrs` is the canonical TypeScript port maintained by the FSRS spec authors; ~10kb min+gz. The cost of getting it wrong (silently scheduling cards incorrectly) is much higher than the dep cost. Council can push back; documented fold path: write a minimal FSRS-5 impl in `packages/lib/srs/src/algorithm.ts` (~200 LOC of pure math) and skip the dep.
 
-### B. SQL function — `supabase/migrations/20260424000001_fn_review_card.sql`
+### B. SQL function + idempotency column — `supabase/migrations/`
+
+**Two migrations, ordered by file timestamp:**
+
+#### B.1 — `20260424000001_review_history_idempotency.sql` (column + unique constraint)
+
+```sql
+-- Council r1 bugs non-negotiable: idempotency key for retry-safe reviews.
+-- A client retry after a network drop must NOT double-apply the rating.
+--
+-- Backfill: existing rows (none in v0 — table is empty post-migration)
+-- get a generated UUID via uuid_generate_v4() so the not-null constraint
+-- holds. The unique (user_id, idempotency_key) index is the dedup key.
+alter table public.review_history
+  add column idempotency_key text;
+
+update public.review_history
+  set idempotency_key = uuid_generate_v4()::text
+  where idempotency_key is null;
+
+alter table public.review_history
+  alter column idempotency_key set not null;
+
+create unique index review_history_idempotency_unique
+  on public.review_history (user_id, idempotency_key);
+
+comment on column public.review_history.idempotency_key is
+  'Client-generated UUIDv4 per rating click. Retries with the same key are no-ops. Council r1 bugs non-negotiable on PR #48.';
+```
+
+#### B.2 — `20260424000002_fn_review_card.sql` (the function)
 
 ```sql
 -- Atomic update: srs_cards.fsrs_state + due_at AND insert review_history,
--- in one transaction. Avoids the "card updated but history insert failed"
--- split-brain that two separate Supabase client calls could produce.
+-- in one transaction. Idempotent on (user_id, idempotency_key); optimistic
+-- concurrency on srs_cards.fsrs_state.
 --
 -- security invoker: caller's auth.uid() flows through to RLS checks on
 -- srs_cards_own + review_history_own. A user can only review their own
@@ -181,13 +256,16 @@ create or replace function public.fn_review_card(
   p_rating smallint,
   p_next_state jsonb,
   p_due_at timestamptz,
-  p_prev_state jsonb
+  p_prev_state jsonb,
+  p_idempotency_key text
 ) returns void
 language plpgsql
 security invoker
 as $$
 declare
   v_user_id uuid;
+  v_inserted_id uuid;
+  v_updated_count int;
 begin
   -- Validate rating range here (defense in depth — server action also checks).
   if p_rating not in (1, 2, 3, 4) then
@@ -195,9 +273,9 @@ begin
   end if;
 
   -- Read user_id from the card row, scoped by RLS. If the row is invisible
-  -- (RLS blocks: not the user's card) OR doesn't exist, this returns 0 rows
-  -- and the subsequent update is a no-op — but the insert below would fail
-  -- on the FK constraint. So fail loudly here instead.
+  -- (RLS blocks: not the user's card) OR doesn't exist, this returns null.
+  -- Fail loud with insufficient_privilege so the server action returns
+  -- card_not_found rather than producing partial state.
   select user_id into v_user_id
     from public.srs_cards
     where id = p_card_id;
@@ -206,71 +284,148 @@ begin
       using errcode = '42501'; -- insufficient_privilege
   end if;
 
-  -- Update the card's state. RLS check is on `using` (read) + `with check`
-  -- (write); both pass since v_user_id = auth.uid() (we just selected it
-  -- under RLS).
+  -- Idempotency check: try to insert review_history first. If the
+  -- (user_id, idempotency_key) pair already exists, this is a retry —
+  -- ON CONFLICT DO NOTHING returns no row, and we short-circuit to a
+  -- successful no-op (the original write already advanced the card state).
+  -- Council r1 bugs non-negotiable: closes the retry-after-network-drop
+  -- double-apply gap.
+  insert into public.review_history (card_id, user_id, rating, prev_state, next_state, idempotency_key)
+    values (p_card_id, v_user_id, p_rating, p_prev_state, p_next_state, p_idempotency_key)
+    on conflict (user_id, idempotency_key) do nothing
+    returning id into v_inserted_id;
+
+  if v_inserted_id is null then
+    -- Replay: the original review already happened. No state mutation
+    -- needed; return success.
+    return;
+  end if;
+
+  -- Optimistic concurrency: update card state ONLY if fsrs_state matches
+  -- what the client computed `next_state` from. If a concurrent
+  -- submitReview already advanced the state, this UPDATE matches 0 rows
+  -- and we raise serialization_failure so the server action can return
+  -- concurrent_update.
+  -- Council r1 bugs non-negotiable: prevents lost-update under concurrent
+  -- rating attempts.
   update public.srs_cards
     set fsrs_state = p_next_state,
         due_at = p_due_at
-    where id = p_card_id;
-
-  -- Insert the review log. RLS `with check` enforces user_id = auth.uid().
-  insert into public.review_history (card_id, user_id, rating, prev_state, next_state)
-    values (p_card_id, v_user_id, p_rating, p_prev_state, p_next_state);
+    where id = p_card_id
+      and fsrs_state = p_prev_state;
+  get diagnostics v_updated_count = row_count;
+  if v_updated_count = 0 then
+    raise exception 'concurrent update on card %', p_card_id
+      using errcode = '40001'; -- serialization_failure
+  end if;
 end;
 $$;
 
-comment on function public.fn_review_card(uuid, smallint, jsonb, timestamptz, jsonb) is
-  'Atomic review: update srs_cards.fsrs_state + due_at AND insert review_history. RLS-scoped via security invoker. Argument order is positional: (card_id, rating, next_state, due_at, prev_state).';
+comment on function public.fn_review_card(uuid, smallint, jsonb, timestamptz, jsonb, text) is
+  'Atomic review: idempotent insert of review_history + optimistic-concurrency update of srs_cards. RLS-scoped via security invoker. Council r1 (PR #48) folded idempotency + optimistic concurrency.';
 
--- Grant exec to authenticated users; RLS does the per-row gating.
-revoke all on function public.fn_review_card(uuid, smallint, jsonb, timestamptz, jsonb) from public;
-grant execute on function public.fn_review_card(uuid, smallint, jsonb, timestamptz, jsonb) to authenticated;
+revoke all on function public.fn_review_card(uuid, smallint, jsonb, timestamptz, jsonb, text) from public;
+grant execute on function public.fn_review_card(uuid, smallint, jsonb, timestamptz, jsonb, text) to authenticated;
+```
+
+#### B.3 — `20260424000003_fn_review_card_down.sql` (down-migration; council r1 arch fold)
+
+```sql
+-- Roll back PR #48 schema changes. Run in reverse order of the up migrations.
+drop function if exists public.fn_review_card(uuid, smallint, jsonb, timestamptz, jsonb, text);
+drop index if exists public.review_history_idempotency_unique;
+alter table public.review_history drop column if exists idempotency_key;
 ```
 
 **Why a SQL function instead of two sequential Supabase client calls:** atomicity. Two client calls = network-level non-atomicity = a partial state where the card's `fsrs_state` advanced but no `review_history` row exists. That's debt: the audit trail is broken, and re-rating the card would compute from the new state without remembering it was just reviewed. A single transaction inside Postgres is the correct boundary.
 
 **Why `security invoker` not `security definer`:** definer would bypass RLS using the function-owner's permissions — defeats the entire RLS model. Invoker means `auth.uid()` is the calling user, and the existing per-user RLS policies on both tables enforce ownership.
 
+**Why insert-history-first then update-card (not the reverse):** the `on conflict do nothing` on the insert is the cheap idempotency check. If we updated the card first then the insert was a replay, we'd have already moved the card state forward unnecessarily. Insert first → on replay, short-circuit return → card untouched. On a fresh review, the insert succeeds → we proceed to the optimistic-concurrency UPDATE.
+
+**Why `40001` on concurrent-update collision:** matches Postgres's standard serialization-failure SQLSTATE so the Supabase client wraps it predictably. The server action distinguishes `40001` from generic errors and returns `errorKind: 'concurrent_update'` so the client can retry-or-recompute (a future UX could re-fetch the card and replay the rating against the new state).
+
 ### C. Server action — `apps/web/app/review/actions.ts`
 
 ```ts
 'use server';
 
-import { redirect } from 'next/navigation';
+import { ZodError } from 'zod';
 import { counter } from '@llmwiki/lib-metrics';
 import {
   isValidRating,
   emptyFsrsState,
   nextState,
+  parseFsrsState,
   type FsrsCardState,
   type RatingValue,
 } from '@llmwiki/lib-srs';
+import { makeRatingLimiter, RateLimitExceededError } from '@llmwiki/lib-ratelimit';
 import { supabaseForRequest } from '../../lib/supabase';
 
 export interface SubmitReviewResult {
   ok: boolean;
-  errorKind?: 'invalid_rating' | 'card_not_found' | 'persist_failed' | 'unauthenticated';
+  errorKind?:
+    | 'invalid_rating'
+    | 'invalid_idempotency_key'
+    | 'card_not_found'
+    | 'persist_failed'
+    | 'invalid_state'         // Zod parse failure on fsrs_state — council r1 bugs fold
+    | 'concurrent_update'     // 40001 from fn_review_card — council r1 bugs fold
+    | 'rate_limited'          // Tier E quota exceeded — council r1 security fold
+    | 'unauthenticated';
 }
 
-export async function submitReview(cardId: string, rating: number): Promise<SubmitReviewResult> {
-  // Reject malformed ratings BEFORE any DB call (defense in depth — fn also checks).
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Tier E limiter: 30 ratings / user / minute. Module-level singleton so the
+// underlying Upstash client is reused across server-action invocations.
+const ratingLimiter = makeRatingLimiter();
+
+export async function submitReview(
+  cardId: string,
+  rating: number,
+  idempotencyKey: string,
+): Promise<SubmitReviewResult> {
+  // Validate inputs BEFORE any DB call. Defense in depth — SQL function also
+  // checks rating range, but cheap-and-loud rejection at the boundary keeps
+  // PostgresError noise out of logs and Tier E quota intact.
   if (!isValidRating(rating)) {
     counter('review.rating.rejected', { reason: 'invalid_rating' });
     return { ok: false, errorKind: 'invalid_rating' };
   }
-  // UUID v4 shape check — Supabase will reject non-UUIDs with a 22P02 anyway,
-  // but cheap to short-circuit + avoid leaking PostgresError noise into logs.
-  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(cardId)) {
+  if (!UUID_RE.test(cardId)) {
     counter('review.rating.rejected', { reason: 'invalid_card_id' });
     return { ok: false, errorKind: 'invalid_rating' };
+  }
+  // Idempotency key must be a UUID-shaped string the client generated via
+  // crypto.randomUUID(). Reject empty / wrong-shape values so a buggy client
+  // can't accidentally collapse all retries onto one bucket.
+  if (!UUID_RE.test(idempotencyKey)) {
+    counter('review.rating.rejected', { reason: 'invalid_idempotency_key' });
+    return { ok: false, errorKind: 'invalid_idempotency_key' };
   }
 
   const rls = await supabaseForRequest();
   const { data: { user } } = await rls.auth.getUser();
   if (!user) {
-    // Don't redirect from a server action — return so the client can navigate.
     return { ok: false, errorKind: 'unauthenticated' };
+  }
+
+  // Per-user rate limit (council r1 security non-negotiable). 30 / user /
+  // minute. Fail-closed on quota exceeded; fail-open on limiter unavailable
+  // (alert + allow) per the Tier B/D pattern.
+  try {
+    await ratingLimiter.reserve(user.id);
+  } catch (err) {
+    if (err instanceof RateLimitExceededError) {
+      counter('review.rating.failed', { reason: 'rate_limited', user_id: user.id });
+      return { ok: false, errorKind: 'rate_limited' };
+    }
+    // RatelimitUnavailableError or unexpected — fail-open with alert (logged
+    // by the limiter helper itself, matching Tier D fail-open posture).
+    // Continue to the rating; better to let a real user through than block on
+    // limiter outage.
   }
 
   // Load the card's current state (RLS-scoped). If the user doesn't own it
@@ -288,37 +443,59 @@ export async function submitReview(cardId: string, rating: number): Promise<Subm
       user_id: user.id,
       card_id: cardId,
     });
-    counter('review.rating.failed', { reason: 'card_not_found' });
+    counter('review.rating.failed', { reason: 'card_not_found', user_id: user.id });
     return { ok: false, errorKind: 'card_not_found' };
   }
 
-  // Compute next state. fsrs_state may be {} for a never-reviewed card —
-  // emptyFsrsState() initializes the FSRS-5 starting point.
-  const currentState =
-    Object.keys(card.fsrs_state ?? {}).length === 0
-      ? emptyFsrsState()
-      : (card.fsrs_state as FsrsCardState);
+  // Council r1 bugs non-negotiable: parse fsrs_state through Zod before
+  // passing to nextState. Malformed JSONB (from a past bug, manual edit, or
+  // schema drift) returns invalid_state instead of crashing.
+  let currentState: FsrsCardState;
+  try {
+    currentState = parseFsrsState(card.fsrs_state) ?? emptyFsrsState();
+  } catch (err) {
+    if (err instanceof ZodError) {
+      console.error('[/review submitReview] invalid_state', {
+        errorName: 'ZodError',
+        issueCount: err.issues.length,  // count only — never issue.path or issue.message
+        user_id: user.id,
+        card_id: cardId,
+      });
+      counter('review.rating.failed', { reason: 'invalid_state', user_id: user.id });
+      return { ok: false, errorKind: 'invalid_state' };
+    }
+    throw err;  // unknown error type — let the framework's error boundary handle it
+  }
 
+  // Compute next state. nextState wraps ts-fsrs in a try-equivalent path;
+  // any throw here would be a library bug (the algorithm is pure math on
+  // validated input). We intentionally do NOT catch — surfacing as an
+  // unhandled error makes the bug visible.
   const { state: next, due } = nextState(currentState, rating as RatingValue);
 
-  // Persist atomically via the SQL function.
+  // Persist atomically via the SQL function (idempotent + optimistic-concurrent).
   const { error: rpcErr } = await rls.rpc('fn_review_card', {
     p_card_id: cardId,
     p_rating: rating,
     p_next_state: next,
     p_due_at: due.toISOString(),
     p_prev_state: currentState,
+    p_idempotency_key: idempotencyKey,
   });
   if (rpcErr) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- supabase error untyped
+    const code = (rpcErr as any)?.code ?? null;
+    // 40001 (serialization_failure) = optimistic-concurrency collision.
+    // Distinct error kind so the client can choose to refetch + retry.
+    const errorKind = code === '40001' ? 'concurrent_update' : 'persist_failed';
     console.error('[/review submitReview] persist_failed', {
       errorName: rpcErr.name ?? 'UnknownError',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- supabase error untyped
-      code: (rpcErr as any)?.code ?? null,
+      code,
       user_id: user.id,
       card_id: cardId,
     });
-    counter('review.rating.failed', { reason: 'persist_failed' });
-    return { ok: false, errorKind: 'persist_failed' };
+    counter('review.rating.failed', { reason: errorKind, user_id: user.id });
+    return { ok: false, errorKind };
   }
 
   counter('review.rating.submitted', {
@@ -330,7 +507,9 @@ export async function submitReview(cardId: string, rating: number): Promise<Subm
 }
 ```
 
-**PII discipline (per CLAUDE.md non-negotiables + the new rebuttal protocol):** error logs include `errorName` + `code` + `user_id` + `card_id` only — never card content, never `error.message` (which can echo query/row text). Counter labels: `user_id`, `card_id` (UUIDs, pseudonyms not PII), `rating` (small int), `is_new_card` (boolean). Card content is NEVER a label.
+**PII discipline (per CLAUDE.md non-negotiables + the new rebuttal protocol):** error logs include `errorName` + `code` + `user_id` + `card_id` only — never card content, never `error.message` (which can echo query/row text), never `ZodError.issues[].message` or `.path` (path could include card content under deep validation). For Zod, only `issues.length` is logged. Counter labels: `user_id`, `card_id` (UUIDs, pseudonyms not PII), `rating` (small int), `is_new_card` (boolean). Card content is NEVER a label.
+
+**Tier E rate-limit posture:** fail-closed on quota exceeded → user sees "rating saved too fast" copy + can retry after the window. Fail-open on limiter unavailable → user proceeds (an outage of Upstash should not block real study sessions; the alert is logged for ops). Matches Tier B/D pattern from PR #28.
 
 ### D. Client wiring — `apps/web/app/review/ReviewDeck.tsx` extension
 
@@ -345,24 +524,42 @@ const handleRate = async (rating: 1 | 2 | 3 | 4) => {
   if (pendingRating) return; // Double-click guard.
   setPendingRating(true);
   setRatingError(null);
+  // Council r1 bugs non-negotiable: client-generated idempotency key.
+  // crypto.randomUUID is available in all modern browsers AND in jsdom 22+;
+  // server-action validates the shape before any DB call.
+  const idempotencyKey = crypto.randomUUID();
   try {
-    const result = await submitReview(card.id, rating);
+    const result = await submitReview(card.id, rating, idempotencyKey);
     if (!result.ok) {
-      setRatingError(t('review.rating_error'));
+      // Distinct copy for rate-limit so user knows to slow down vs. retry.
+      const copyKey =
+        result.errorKind === 'rate_limited'
+          ? 'review.rating_rate_limit_error'
+          : 'review.rating_error';
+      setRatingError(t(copyKey));
+      // Council r1 nice-to-have: log a generic, PII-safe debug line for
+      // ops visibility (errorKind is a bounded enum, not card content).
+      console.error('[ReviewDeck] rating_failed', { errorKind: result.errorKind });
       setPendingRating(false);
       return;
     }
     counter('review.card.rated', { rating: String(rating) });
-    handleNext(); // Advances + re-hides answer.
+    handleNext(); // Advances + re-hides answer; existing useEffect on [index]
+                  // moves focus to the sr-only heading (council r1 a11y fold —
+                  // re-uses the focus-mgmt path PR #42 already shipped + tested).
     setPendingRating(false);
-  } catch {
+  } catch (err) {
     // Server action threw (network, etc.). Don't log error.message — could
-    // contain serialized server state.
+    // contain serialized server state. Log only error class for ops visibility.
+    const errorName = err instanceof Error ? err.name : typeof err;
+    console.error('[ReviewDeck] rating_threw', { errorName });
     setRatingError(t('review.rating_error'));
     setPendingRating(false);
   }
 };
 ```
+
+**Focus management on auto-advance (council r1 a11y non-negotiable):** the existing `useEffect` on `[index]` in `ReviewDeck` (shipped in PR #42) already moves focus to the sr-only `headingRef` whenever `index` changes — and `handleNext()` increments `index`. So the rating → success → `handleNext()` path automatically triggers the same focus move that PR #42's "Next card" button does. No new code needed; the ReviewDeck.test.tsx test extension simply asserts that calling `handleRate` followed by `submitReview` returning `{ok: true}` results in `headingRef.current.focus()` being called (spied via the existing test seam). The test is the proof per the rebuttal-protocol rule.
 
 ```tsx
 // JSX additions, rendered only when revealed:
@@ -406,6 +603,7 @@ const handleRate = async (rating: 1 | 2 | 3 | 4) => {
 'review.rating.good': 'Good',
 'review.rating.easy': 'Easy',
 'review.rating_error': "Couldn't save your rating. Please try again.",
+'review.rating_rate_limit_error': "You're rating too quickly. Please wait a moment.",
 'review.rating_pending': 'Saving…',
 ```
 
@@ -436,47 +634,69 @@ Each component has BOTH happy-path AND failure-mode coverage. Failure-mode cover
   - `nextState(state, 5 as RatingValue)` — passing an invalid rating that's been (incorrectly) cast — does NOT silently produce a result; either throws or returns a sentinel. (ts-fsrs behavior TBD; test pins the contract whichever way it goes.)
   - `nextState` is determinism-tolerant: re-calling with same args + same `now` produces the same `state` shape, same `reps`/`lapses`/`state`. Fuzz-on may vary `due` by ±a small fraction; test asserts ordering, not exact value.
 
-### `apps/web/app/review/actions.test.ts` (server-action behavior; ~10 tests)
+### `apps/web/app/review/actions.test.ts` (server-action behavior; ~16 tests)
 
 - **Happy path:**
-  - `submitReview(validId, 3)` with authed user + valid card → `{ok: true}` + `fn_review_card` RPC called with correct args + `review.rating.submitted` counter fired.
-  - `submitReview` on a never-reviewed card (`fsrs_state = {}`) → `nextState` is called with `emptyFsrsState()`, not `{}` directly.
+  - `submitReview(validId, 3, validKey)` with authed user + valid card → `{ok: true}` + `fn_review_card` RPC called with correct args (incl. `p_idempotency_key`) + `review.rating.submitted` counter fired.
+  - `submitReview` on a never-reviewed card (`fsrs_state = {}`) → `parseFsrsState` returns `null` → `emptyFsrsState()` used; `nextState` called with the empty starting point, not `{}` directly.
 - **Failure modes (the rebuttal-protocol failure-mode proof for this surface):**
-  - `submitReview(validId, 0)` → `{ok: false, errorKind: 'invalid_rating'}` + `review.rating.rejected` counter + NO Supabase calls made.
-  - `submitReview(validId, 5)` → same.
-  - `submitReview('not-a-uuid', 3)` → `{ok: false, errorKind: 'invalid_rating'}` + counter + no Supabase calls.
-  - `submitReview(validId, 3)` with no auth user → `{ok: false, errorKind: 'unauthenticated'}` + no `from('srs_cards')` call.
-  - Card not owned by user (RLS blocks the select → returns null) → `{ok: false, errorKind: 'card_not_found'}` + log shape verified PII-safe (negative-assert sentinel string).
-  - `fn_review_card` RPC returns error → `{ok: false, errorKind: 'persist_failed'}` + log shape PII-safe + `review.rating.failed` counter with `reason: 'persist_failed'`.
-  - **PII negative assertion:** stub the RPC to return an error with `message: 'CARDCONTENT_SECRET_DO_NOT_LOG: relation x'` — assert `JSON.stringify(spy.mock.calls)` does NOT contain the sentinel.
-  - Counter labels never include card content (negative assert).
+  - `submitReview(validId, 0, validKey)` → `{ok: false, errorKind: 'invalid_rating'}` + `review.rating.rejected` counter + NO Supabase calls.
+  - `submitReview(validId, 5, validKey)` → same.
+  - `submitReview('not-a-uuid', 3, validKey)` → `{ok: false, errorKind: 'invalid_rating'}` + counter + no Supabase calls.
+  - `submitReview(validId, 3, '')` → `{ok: false, errorKind: 'invalid_idempotency_key'}` + `review.rating.rejected` counter (`reason: 'invalid_idempotency_key'`) + no Supabase calls.
+  - `submitReview(validId, 3, 'not-a-uuid')` → same.
+  - `submitReview(validId, 3, validKey)` with no auth user → `{ok: false, errorKind: 'unauthenticated'}` + no `from('srs_cards')` call + no rate-limiter call.
+  - **Council r1 security non-negotiable: explicit RLS-blocked test in this consistently-passing suite.** Stub `getUser` returns User A, stub `from('srs_cards').select().eq().single()` returns `{data: null, error: {code: 'PGRST116', message: 'NotFound'}}` (PostgREST's RLS-block shape) → `{ok: false, errorKind: 'card_not_found'}` + log shape verified PII-safe + counter fired with `reason: 'card_not_found'`. This is the failure-mode proof that User A cannot review User B's card via the RLS-scoped client.
+  - **Council r1 bugs non-negotiable: idempotency replay is a no-op success.** Stub `fn_review_card` to return success on FIRST call. Run `submitReview(validId, 3, sameKey)` twice in sequence; assert second call still returns `{ok: true}` (RPC handled the dedup) and the second `submitReview` invocation's RPC call args include `p_idempotency_key: sameKey`. The on-conflict-do-nothing behavior is tested in pgTAP; this test verifies the server action's contract.
+  - **Council r1 bugs non-negotiable: concurrent-update collision returns distinct error.** Stub `fn_review_card` to return `{error: {code: '40001', name: 'PostgresError', message: 'serialization_failure'}}` → `{ok: false, errorKind: 'concurrent_update'}` + counter (`reason: 'concurrent_update'`) + log shape PII-safe.
+  - **Council r1 bugs non-negotiable: malformed `fsrs_state` returns invalid_state.** Stub the select to return `{data: {id, fsrs_state: {due: 12345}}, error: null}` (numeric `due` instead of ISO string → ZodError) → `{ok: false, errorKind: 'invalid_state'}` + log shape includes `errorName: 'ZodError'` + `issueCount` (a number) + counter; **assert log args do NOT contain `issue.path` or `issue.message`** (negative-assert sentinel: stub a malformed value `{due: 'PII_SENTINEL_DO_NOT_LOG'}` and assert serialized args don't contain the sentinel).
+  - **Council r1 security non-negotiable: rate-limit exceeded.** Stub `ratingLimiter.reserve` to throw `RateLimitExceededError` → `{ok: false, errorKind: 'rate_limited'}` + counter (`reason: 'rate_limited'`) + NO `from('srs_cards')` call (rate-limit fires before the DB read).
+  - **Rate-limit unavailable (Tier B/D fail-open posture):** stub `ratingLimiter.reserve` to throw `RatelimitUnavailableError` → continues to the rating (does NOT block) + the limiter helper logs the alert internally (verified by spying on the alert path).
+  - `fn_review_card` RPC returns generic error (not 40001) → `{ok: false, errorKind: 'persist_failed'}` + log shape PII-safe + `review.rating.failed` counter with `reason: 'persist_failed'`.
+  - **PII negative assertion (canonical):** stub the RPC to return an error with `message: 'CARDCONTENT_SECRET_DO_NOT_LOG: relation x'` — assert `JSON.stringify(spy.mock.calls)` does NOT contain the sentinel.
+  - Counter labels never include card content (negative assert across all paths).
 
-### `apps/web/components/ReviewDeck.test.tsx` (UI integration; ~6 new tests)
+### `apps/web/components/ReviewDeck.test.tsx` (UI integration; ~9 new tests)
 
 - Rating buttons NOT rendered when `revealed === false` (assert markup absence).
 - Rating buttons rendered when `revealed === true`.
 - Rating buttons have `min-h-[44px]` + `role="group"` + `aria-label`.
-- Clicking Again/Hard/Good/Easy fires `submitReview` with the right rating value (mock the action).
-- On `{ok: false}`, error banner renders with `role="alert"`.
+- Clicking Again/Hard/Good/Easy fires `submitReview` with the right rating value AND a `crypto.randomUUID`-shaped `idempotencyKey` (mock the action; assert third arg matches `UUID_RE`).
+- On `{ok: false, errorKind: 'rate_limited'}`, error banner renders the rate-limit-specific copy (`review.rating_rate_limit_error`) with `role="alert"`.
+- On any other `{ok: false}`, error banner renders the generic copy (`review.rating_error`).
 - On `{ok: true}`, advances to next card (index increments + answer re-hides).
+- **Council r1 a11y non-negotiable: focus moves to next card heading after auto-advance.** Spy on `headingRef.current.focus`; rate a card; await success; assert focus was called on the new card's heading. Re-uses the focus-mgmt seam shipped in PR #42.
 - **Failure-mode:** double-click on a rating button doesn't fire `submitReview` twice (`pendingRating` guard).
+- **Failure-mode:** unique idempotency key per click — clicking Again then (after error) clicking Hard generates two DIFFERENT keys (assert via spy on `crypto.randomUUID`).
+
+### `packages/lib/ratelimit/src/index.test.ts` (Tier E extension; ~3 new tests)
+
+- `makeRatingLimiter` returns a limiter that allows the 30th call in a minute.
+- 31st call throws `RateLimitExceededError`.
+- Different `userId` keys are isolated (User A's quota does not deplete User B's).
 
 ### `supabase/tests/fn_review_card.sql` (pgTAP; non-load-bearing per #7)
 
 - Function signature exists.
 - User A cannot review User B's card (returns RLS error).
 - Invalid rating raises `22023`.
+- Idempotency: second call with same `(user_id, idempotency_key)` returns success without creating a duplicate `review_history` row OR re-advancing `srs_cards.fsrs_state`.
+- Concurrency: when `p_prev_state` doesn't match the current `srs_cards.fsrs_state`, raises `40001`.
 - Atomicity: when called inside a savepoint that we then roll back, neither table changes (proves the function is participating in the transaction).
 
-**Note per the new rebuttal-protocol rule:** the pgTAP suite is `continue-on-error` and known-flaky (#7). It cannot be cited as the proof for the RLS rebuttal protocol. The `supabaseForRequest` server-action tests above ARE the consistently-passing failure-mode proof for the `card_not_found` (RLS-blocked) path.
+**Note per the new rebuttal-protocol rule:** the pgTAP suite is `continue-on-error` and known-flaky (#7). It cannot be cited as the proof for the rebuttal protocol. The `supabaseForRequest` server-action tests above ARE the consistently-passing failure-mode proof for the `card_not_found` (RLS-blocked), `concurrent_update` (40001), and idempotency-replay paths. Council r1 security non-negotiable: explicit RLS-blocked test in `actions.test.ts` is the canonical proof; pgTAP is corroborating.
 
 ## Risks
 
 1. **`ts-fsrs` runtime dep adds bundle size.** ~10kb min+gz. The lib is server-side only (the algorithm runs in the server action), so the client bundle is unaffected. `ts-fsrs` only needs to be installed in the workspace package that imports it (`packages/lib/srs/`). Confirm via bundle-analyzer post-merge.
 2. **Algorithm-correctness risk if `ts-fsrs` has bugs.** Mitigated by the ordering-invariant property test in §Tests (if math breaks, ordering breaks). FSRS-5 is a well-published spec; lib is the canonical TypeScript port.
 3. **`security invoker` + RLS interaction subtleties.** The function's `select user_id into v_user_id` runs under the caller's auth context — if RLS blocks the select, `v_user_id` is null and we raise `42501`. Tested via the `card_not_found` server-action test path (consistently passing).
-4. **Rapid-rating race conditions.** User clicks Again then immediately Good for the same card before the first server action returns. Mitigated by `pendingRating` state in the client + `useState` updater discipline. Tested.
-5. **`ts-fsrs` API stability.** Pin to an exact version in `package.json`; document in a comment that bumps need a council round (algorithm changes between FSRS-4 and FSRS-5 mattered; future bumps could too).
+4. **Rapid-rating race conditions.** User clicks Again then immediately Good for the same card before the first server action returns. Mitigated at THREE layers (council r1 bugs fold):
+   - **Client:** `pendingRating` state guards against double-clicks within a single tab.
+   - **Server idempotency:** if the second click somehow reuses the same `idempotencyKey`, the SQL function's `on conflict do nothing` short-circuits the second to a no-op.
+   - **Server optimistic concurrency:** if the second click generates a NEW key but races against the first's commit, the `WHERE fsrs_state = p_prev_state` UPDATE matches 0 rows → raises `40001` → server returns `concurrent_update`. Client re-fetches + re-rates against the new state.
+   The three layers cover (a) same-tab double-click, (b) network retry of one click, (c) two-tab concurrent rating respectively. Tested.
+5. **`ts-fsrs` API stability.** Pinned to an exact version in `packages/lib/srs/package.json` (council r1 security non-negotiable). Comment in the package.json + a `// VERSION-PINNED` comment in the wrapper file note that bumps require a council round (algorithm changes between FSRS-4 and FSRS-5 mattered; future bumps could too).
 6. **Migration ordering.** New migration `20260424000001` runs after the existing `20260422000001_srs_cards_unique.sql`. Idempotent (uses `create or replace function`). Safe to re-run.
 7. **No "undo" for an accidental rating.** Acknowledged out-of-scope; the lapse counter recovers from one wrong click via the next review's Again rating. Real undo is a UX feature for v2.
 
@@ -500,16 +720,26 @@ Zero net runtime cost. The `submitReview` server action makes 1 Supabase select 
 ## Acceptance criteria
 
 - [ ] User can click Again/Hard/Good/Easy after revealing an answer; click is disabled when answer is hidden.
-- [ ] Click triggers `submitReview` server action; response advances to next card on success.
+- [ ] Click triggers `submitReview` server action with a fresh `crypto.randomUUID()` idempotency key; response advances to next card on success.
 - [ ] `srs_cards.fsrs_state` + `srs_cards.due_at` updated atomically with `review_history` insert.
 - [ ] Never-reviewed card (`fsrs_state = {}`) initializes via `emptyFsrsState()` on first review.
-- [ ] Unauthenticated rating attempts return `unauthenticated` error kind, no DB writes.
-- [ ] User cannot review another user's card (RLS blocks via `security invoker`).
+- [ ] Unauthenticated rating attempts return `unauthenticated` error kind, no DB writes, no rate-limit consumption.
+- [ ] User cannot review another user's card (RLS blocks via `security invoker`); explicit test in `actions.test.ts` (consistently passing) per the new rebuttal-protocol rule.
 - [ ] Invalid rating values rejected before any DB call.
+- [ ] Invalid idempotency-key shape rejected before any DB call.
+- [ ] **Idempotency:** retry with same key is a no-op success; `srs_cards.fsrs_state` unchanged; no duplicate `review_history` row.
+- [ ] **Optimistic concurrency:** second concurrent rating returns `concurrent_update` errorKind; first rating's state is preserved.
+- [ ] **Zod parse:** malformed `fsrs_state` returns `invalid_state` errorKind; ZodError logged with `issueCount` only (never `issue.path` or `issue.message`).
+- [ ] **Rate limit:** Tier E enforces 30/user/min; 31st rating in a minute returns `rate_limited` errorKind.
+- [ ] **Rate-limit fail-open:** if the limiter is unavailable, the rating proceeds (alert logged, user not blocked).
 - [ ] Server-action error logs are PII-safe (failure-mode test asserts negatively against sentinel).
 - [ ] Counter labels never include card content (failure-mode test asserts negatively).
 - [ ] `ordering invariant` property test passes for FSRS algorithm contract.
 - [ ] All buttons ≥44px touch target, `role="group"` on rating cluster, `aria-label` present.
+- [ ] **Focus moves to next card heading after auto-advance** (failure-mode test on the focus seam from PR #42).
+- [ ] **`bg-warning` + `text-brand-900` contrast verified** to meet WCAG AA (3:1 for UI components); `axe-core` smoke test extended to include rating cluster markup.
+- [ ] **`ts-fsrs` pinned to exact version** in `packages/lib/srs/package.json` (no `^` / `~`).
+- [ ] **Down-migration exists** at `supabase/migrations/20260424000003_fn_review_card_down.sql`.
 - [ ] `npm run lint`, `npm run typecheck`, `npm test` pass.
 - [ ] Council PROCEED on the impl-diff round.
 

--- a/.harness/active_plan.md
+++ b/.harness/active_plan.md
@@ -1,419 +1,523 @@
-# Plan: /review UI — render srs_cards with plain-text XSS-safe rendering (issue #38)
+# Plan: FSRS rating + scheduling on /review (closes the SRS loop)
 
-**Status:** r2 — folding council r1 PROCEED with bugs=6 substantive asks (try/catch + PII-safe error logging + focus management + metrics). Awaiting council r2 + human approval.
-**Branch:** `claude/review-ui`.
-**Scope:** first user-facing surface on the SRS pipeline. Server Component reads `srs_cards` via RLS, Client Component owns the reveal-answer toggle. Plain-text rendering only (no `dangerouslySetInnerHTML`). New unit + a11y tests. **No `[skip council]`.**
+**Status:** draft, awaiting council + human approval.
+**Branch:** `claude/fsrs-scoring`.
+**Scope:** rating UI on `/review` (Again/Hard/Good/Easy) + server action that runs the FSRS algorithm + persists state. New runtime dep (`ts-fsrs`). New typed wrappers around `srs_cards.fsrs_state` and `review_history.{prev,next}_state`. **No `[skip council]`** — new external lib + auth-gated mutation surface + the kind of state-machine math council should scrutinize.
 
 ## Problem
 
-PR #37 (`e52866c`) shipped the flashcard generation handler: when a PDF ingest completes, Claude Haiku produces 5–10 cards and persists them to `srs_cards`. The pipeline is end-to-end functional on the data side, but **the cards are dead on arrival** — there is no `/review` route at `apps/web/app/review/` (verified: directory does not exist). Until this UI ships, no user can see the SRS loop work, and the product has no visible value beyond the upload-and-list dashboard.
-
-Issue #38 was filed during PR #37's council r2 with the XSS sanitization requirement promoted to a non-negotiable: `srs_cards.question` and `srs_cards.answer` are LLM output from user-uploaded PDFs, so a crafted PDF could embed HTML/JS that Claude passes through verbatim. Migration `20260422000001_srs_cards_unique.sql` annotated those columns with `COMMENT ON COLUMN ... IS 'LLM-generated from user-uploaded content. MUST be sanitized before rendering.'` — the canonical record of this requirement. This PR honors that contract.
+PR #42 shipped `/review` as a read-only surface — users see their cards but cannot rate them. Without rating, the entire "spaced repetition" value prop is inert: `srs_cards.fsrs_state` is always `{}`, `srs_cards.due_at` is always `null`, `review_history` is always empty, and the user reviews the same N cards forever in `created_at desc` order. The product persona on PR #43 r5 explicitly: *"`/review` UI without scoring is 'look at the same cards forever'; rating closes the loop and validates the entire ingest → flashcards → review → retention pipeline."*
 
 ## Goal
 
-A `/review` route at `apps/web/app/review/page.tsx` that:
+After this PR ships, a user on `/review` can:
 
-1. Authenticates the request (redirect to `/auth` on unauthenticated, matching `apps/web/app/page.tsx:11-14`).
-2. Fetches the user's cards via the RLS-scoped client (`supabaseForRequest`), bounded to a small page (20).
-3. Renders one card at a time as **plain text** — question shown by default, answer hidden until reveal.
-4. Handles the empty state (no cards yet) with a clear copy directing to upload.
-5. Passes a11y: WCAG AA contrast, ≥44px touch targets, `aria-live` reveal announcement, focus-management on next-card.
-6. Has a unit test that proves a card with `question: '<script>alert(1)</script>'` renders as the literal escaped string and never executes.
+1. Reveal an answer (existing).
+2. Rate the card with one of four buttons: **Again** (forgot completely), **Hard** (recalled with difficulty), **Good** (recalled correctly), **Easy** (trivially correct). Buttons are disabled until the answer is revealed (you can't rate what you haven't tried to recall).
+3. On click, the server runs the FSRS algorithm against the card's current `fsrs_state`, computes a new `(state, due_at)` pair, persists both updates to `srs_cards` AND inserts a `review_history` row in a single transaction.
+4. The client advances to the next card and re-hides the answer.
+5. New cards (with `fsrs_state = {}`) initialize cleanly on first review.
 
-Explicitly **not** in scope: FSRS rating buttons, next-review-date scheduling, markdown rendering, edit/delete UI, keyboard shortcuts, session-based bulk-review. Each is its own follow-up.
+The /review query stays unchanged in this PR — still `order by created_at desc limit 20`. **Due-now filtering** (only show cards where `due_at <= now()`) is explicitly out of scope; this PR's job is to make the FSRS loop *work*, not to reorganize the queue. Due-filtering is a separate ticket once the rating UX is validated.
 
 ## Scope
 
 **In:**
 
-- `apps/web/app/review/page.tsx` — new Server Component. Auth check, RLS read of `srs_cards`, passes initial card list to a client child. `export const dynamic = 'force-dynamic'` (auth-gated, per-user).
-- `apps/web/app/review/ReviewDeck.tsx` — new Client Component (`'use client'`). Owns: which-card-index state, answer-revealed boolean, "next card" handler. Renders `{card.question}` / `{card.answer}` as text nodes — never `dangerouslySetInnerHTML`.
-- `apps/web/lib/i18n.ts` — add 5 keys: `review.heading`, `review.empty`, `review.show_answer`, `review.hide_answer`, `review.load_error`. Update the `Key` union and `STRINGS` map.
-- `apps/web/components/ReviewDeck.test.tsx` — vitest unit test covering: (a) XSS payload renders escaped, (b) reveal toggle flips answer visibility, (c) "next card" advances index and re-hides the answer, (d) empty array renders the empty-state copy.
-  - Uses `react-dom/server`'s `renderToStaticMarkup` (already a transitive dep via `react-dom@^19`); no new runtime dep, no jsdom needed (vitest env stays `node` per `apps/web/vitest.config.ts`).
-  - Note: `ReviewDeck` is the Client Component, but `'use client'` is a bundler directive — in a pure unit-test context the file imports as a normal React module.
-- `apps/web/tests/unit/review-page.test.ts` — route-module integration test mirroring `auth-callback-route.test.ts`'s shape: stubs `supabaseForRequest`, asserts unauthenticated → redirect, asserts `srs_cards` query is RLS-scoped (uses the wrapped client, not `supabaseService`).
-- `apps/web/tests/a11y/smoke.spec.ts` — extend the placeholder to include a `/review` static-HTML axe pass for color-contrast + target-size, modeled on the existing pattern. (Real page.goto stays gated on the dev-server CI todo.)
+- `apps/web/package.json` — add `ts-fsrs` (pinned, exact version). Runtime dep.
+- `packages/lib/srs/` — new tiny package wrapping `ts-fsrs` with our domain types + a single `nextState(currentState, rating)` pure function. Reasons for a wrapper package:
+  1. Keeps `ts-fsrs` import surface narrow — only one file imports it.
+  2. Lets us swap the underlying lib later without touching app code.
+  3. Provides a single test-target for the algorithm contract (failure-mode tests live here per the new rebuttal-protocol rule).
+- `apps/web/app/review/actions.ts` — new server action `submitReview(cardId, rating)`. RLS-scoped via `supabaseForRequest`; runs `nextState`; persists via a Postgres function (`fn_review_card`) called via Supabase RPC for atomicity.
+- `supabase/migrations/20260424000001_fn_review_card.sql` — new SQL function `fn_review_card(p_card_id uuid, p_rating smallint, p_next_state jsonb, p_due_at timestamptz, p_prev_state jsonb)` that updates `srs_cards.fsrs_state` + `due_at` AND inserts `review_history` in a single transaction. RLS via `security invoker` (so the caller's `auth.uid()` is checked against `srs_cards_own` + `review_history_own`).
+- `apps/web/app/review/ReviewDeck.tsx` — extend with rating buttons (4 buttons after answer reveal, hidden before reveal); wire to the server action; on success, call existing `handleNext`.
+- `apps/web/lib/i18n.ts` — 6 new keys: `review.rating.again`, `review.rating.hard`, `review.rating.good`, `review.rating.easy`, `review.rating_error`, `review.rating_pending`.
+- Tests:
+  - `packages/lib/srs/src/index.test.ts` — algorithm contract, failure-mode coverage (see §Tests).
+  - `apps/web/app/review/actions.test.ts` — server-action behavior, RLS enforcement, transaction atomicity stub, PII-safe logging, rating validation.
+  - `apps/web/components/ReviewDeck.test.tsx` — rating buttons disabled before reveal, enabled after, fire on click, advance card on success.
+  - `supabase/tests/fn_review_card.sql` — pgTAP test for the SQL function (acknowledged-flaky per #7; written but not load-bearing for the rebuttal protocol).
 
 **Out (explicit):**
 
-- FSRS scoring / rating buttons / `review_history` writes — separate follow-up; the schema is ready (`packages/db/src/types.ts:101` `ReviewHistory`) but the algorithm + UI pattern need their own plan.
-- Markdown rendering for cards — issue #38 mandates plain text for v0. If a future need emerges, route through `react-markdown + rehype-sanitize` like `/note/[slug]` does, with allowlist explicitly tightened.
-- Card edit / delete UI.
-- "Due-now" filtering via `due_at` — the partial index `srs_cards_user_due_idx` is in place (`supabase/migrations/20260422000001_srs_cards_unique.sql:17-19`) but v0 just shows all of the user's cards by `created_at desc`. Due filtering arrives with FSRS scoring.
-- Pagination beyond a 20-card page. v0 cap is fine — the user has at most ~10 cards per ingested note in the early path.
-- Keyboard shortcuts (Space to reveal, J/K to navigate). Nice-to-have; trivial follow-up once the core flow is reviewed.
-- Realtime subscription for newly-generated cards. Static page-load fetch is fine for v0; user can refresh.
+- **Due-now filtering on `/review`'s initial query** — separate ticket once rating UX is validated.
+- **Per-user FSRS parameter tuning** (advanced FSRS feature for personalized intervals) — defaults are fine for v1.
+- **Anki-style multi-deck management** — single global deck per user.
+- **Review session boundaries** ("review 20 cards then stop") — cards are rated as they come up; user closes the tab to end.
+- **Heatmap / streak tracking** — separate analytics surface.
+- **Undo last review** — accept the rating once submitted; the lapse counter handles "I clicked wrong" via the next-review's Again rating.
+- **Mobile gesture support** (swipe to rate) — keyboard + click only for v1.
+- **Keyboard shortcuts** (1/2/3/4 to rate) — nice-to-have follow-up.
+
+## Data isolation model (per CLAUDE.md §"Plan-time required content")
+
+Two tables touched by this PR; neither is new:
+
+- **`srs_cards`** — **per-user** (already shipped at `supabase/migrations/20260417000002_rls_policies.sql:118-121`). Justification: a study group's flashcards are personal study aids — only the owning user reviews their own cards. This PR mutates the row's `fsrs_state` + `due_at`, which are the per-user review state.
+- **`review_history`** — **per-user** (already shipped at `supabase/migrations/20260417000002_rls_policies.sql:125-128`). Justification: a user's review history is a personal study log — only the owning user reads/writes their own entries. This PR inserts new rows.
+
+The new SQL function `fn_review_card` runs as `security invoker` so `auth.uid()` flows through to the RLS check on both tables. **No new tables introduced; no new RLS policies needed.**
 
 ## Design
 
-### A. Server Component — `apps/web/app/review/page.tsx`
+### A. FSRS wrapper package — `packages/lib/srs/`
 
 ```ts
+// packages/lib/srs/src/index.ts
+import { FSRS, generatorParameters, Rating, type Card } from 'ts-fsrs';
+
+export const RATING_AGAIN = 1;
+export const RATING_HARD = 2;
+export const RATING_GOOD = 3;
+export const RATING_EASY = 4;
+export type RatingValue = 1 | 2 | 3 | 4;
+
+export function isValidRating(r: unknown): r is RatingValue {
+  return r === 1 || r === 2 || r === 3 || r === 4;
+}
+
+/**
+ * Our wire shape for srs_cards.fsrs_state and review_history.{prev,next}_state.
+ * Matches ts-fsrs's Card serialization 1:1; explicit interface so a future
+ * lib swap can target a stable contract.
+ */
+export interface FsrsCardState {
+  due: string;             // ISO timestamp
+  stability: number;
+  difficulty: number;
+  elapsed_days: number;
+  scheduled_days: number;
+  reps: number;
+  lapses: number;
+  state: 0 | 1 | 2 | 3;    // 0=new, 1=learning, 2=review, 3=relearning
+  last_review?: string;    // ISO timestamp; undefined for never-reviewed
+}
+
+/**
+ * Initial state for a never-reviewed card. Matches ts-fsrs's createEmptyCard()
+ * output but spelled out so the contract is readable.
+ */
+export function emptyFsrsState(now: Date = new Date()): FsrsCardState {
+  return {
+    due: now.toISOString(),
+    stability: 0,
+    difficulty: 0,
+    elapsed_days: 0,
+    scheduled_days: 0,
+    reps: 0,
+    lapses: 0,
+    state: 0,
+  };
+}
+
+const fsrs = new FSRS(generatorParameters({ enable_fuzz: true }));
+
+/**
+ * Pure function: given the current state + a rating + "now", compute the
+ * next state and the next due date. Throws on invalid rating (caller must
+ * validate first via isValidRating).
+ *
+ * "Pure" with one caveat: ts-fsrs's enable_fuzz=true adds randomness to the
+ * scheduled interval (anti-clustering on cards reviewed in batches). Tests
+ * that assert exact intervals must seed Math.random or disable fuzz; tests
+ * that assert ordering ("Easy interval > Good interval > Hard interval >
+ * Again interval") are fuzz-stable.
+ */
+export function nextState(
+  current: FsrsCardState,
+  rating: RatingValue,
+  now: Date = new Date(),
+): { state: FsrsCardState; due: Date } {
+  // Convert FsrsCardState (our wire) → ts-fsrs Card (their internal).
+  const card: Card = {
+    due: new Date(current.due),
+    stability: current.stability,
+    difficulty: current.difficulty,
+    elapsed_days: current.elapsed_days,
+    scheduled_days: current.scheduled_days,
+    reps: current.reps,
+    lapses: current.lapses,
+    state: current.state as Card['state'],
+    last_review: current.last_review ? new Date(current.last_review) : undefined,
+  };
+
+  const result = fsrs.next(card, now, rating as Rating);
+  const next = result.card;
+
+  return {
+    state: {
+      due: next.due.toISOString(),
+      stability: next.stability,
+      difficulty: next.difficulty,
+      elapsed_days: next.elapsed_days,
+      scheduled_days: next.scheduled_days,
+      reps: next.reps,
+      lapses: next.lapses,
+      state: next.state as FsrsCardState['state'],
+      last_review: next.last_review?.toISOString(),
+    },
+    due: next.due,
+  };
+}
+```
+
+**Why a wrapper package:** keeps `ts-fsrs` imports localized to one file. If we later swap to `super-memo` or roll our own, only this file changes. Council can audit the algorithm contract (the test suite below) without combing through call-sites.
+
+**Why `ts-fsrs` over rolling our own:** the FSRS-5 algorithm has subtle math (logarithmic stability decay, retrievability formulas, difficulty drift). `ts-fsrs` is the canonical TypeScript port maintained by the FSRS spec authors; ~10kb min+gz. The cost of getting it wrong (silently scheduling cards incorrectly) is much higher than the dep cost. Council can push back; documented fold path: write a minimal FSRS-5 impl in `packages/lib/srs/src/algorithm.ts` (~200 LOC of pure math) and skip the dep.
+
+### B. SQL function — `supabase/migrations/20260424000001_fn_review_card.sql`
+
+```sql
+-- Atomic update: srs_cards.fsrs_state + due_at AND insert review_history,
+-- in one transaction. Avoids the "card updated but history insert failed"
+-- split-brain that two separate Supabase client calls could produce.
+--
+-- security invoker: caller's auth.uid() flows through to RLS checks on
+-- srs_cards_own + review_history_own. A user can only review their own
+-- cards.
+create or replace function public.fn_review_card(
+  p_card_id uuid,
+  p_rating smallint,
+  p_next_state jsonb,
+  p_due_at timestamptz,
+  p_prev_state jsonb
+) returns void
+language plpgsql
+security invoker
+as $$
+declare
+  v_user_id uuid;
+begin
+  -- Validate rating range here (defense in depth — server action also checks).
+  if p_rating not in (1, 2, 3, 4) then
+    raise exception 'invalid rating: %', p_rating using errcode = '22023';
+  end if;
+
+  -- Read user_id from the card row, scoped by RLS. If the row is invisible
+  -- (RLS blocks: not the user's card) OR doesn't exist, this returns 0 rows
+  -- and the subsequent update is a no-op — but the insert below would fail
+  -- on the FK constraint. So fail loudly here instead.
+  select user_id into v_user_id
+    from public.srs_cards
+    where id = p_card_id;
+  if v_user_id is null then
+    raise exception 'card not found or not accessible: %', p_card_id
+      using errcode = '42501'; -- insufficient_privilege
+  end if;
+
+  -- Update the card's state. RLS check is on `using` (read) + `with check`
+  -- (write); both pass since v_user_id = auth.uid() (we just selected it
+  -- under RLS).
+  update public.srs_cards
+    set fsrs_state = p_next_state,
+        due_at = p_due_at
+    where id = p_card_id;
+
+  -- Insert the review log. RLS `with check` enforces user_id = auth.uid().
+  insert into public.review_history (card_id, user_id, rating, prev_state, next_state)
+    values (p_card_id, v_user_id, p_rating, p_prev_state, p_next_state);
+end;
+$$;
+
+comment on function public.fn_review_card(uuid, smallint, jsonb, timestamptz, jsonb) is
+  'Atomic review: update srs_cards.fsrs_state + due_at AND insert review_history. RLS-scoped via security invoker. Argument order is positional: (card_id, rating, next_state, due_at, prev_state).';
+
+-- Grant exec to authenticated users; RLS does the per-row gating.
+revoke all on function public.fn_review_card(uuid, smallint, jsonb, timestamptz, jsonb) from public;
+grant execute on function public.fn_review_card(uuid, smallint, jsonb, timestamptz, jsonb) to authenticated;
+```
+
+**Why a SQL function instead of two sequential Supabase client calls:** atomicity. Two client calls = network-level non-atomicity = a partial state where the card's `fsrs_state` advanced but no `review_history` row exists. That's debt: the audit trail is broken, and re-rating the card would compute from the new state without remembering it was just reviewed. A single transaction inside Postgres is the correct boundary.
+
+**Why `security invoker` not `security definer`:** definer would bypass RLS using the function-owner's permissions — defeats the entire RLS model. Invoker means `auth.uid()` is the calling user, and the existing per-user RLS policies on both tables enforce ownership.
+
+### C. Server action — `apps/web/app/review/actions.ts`
+
+```ts
+'use server';
+
 import { redirect } from 'next/navigation';
 import { counter } from '@llmwiki/lib-metrics';
+import {
+  isValidRating,
+  emptyFsrsState,
+  nextState,
+  type FsrsCardState,
+  type RatingValue,
+} from '@llmwiki/lib-srs';
 import { supabaseForRequest } from '../../lib/supabase';
-import { ReviewDeck } from './ReviewDeck';
-import { t } from '../../lib/i18n';
-import type { SrsCard } from '@llmwiki/db/types';
 
-export const dynamic = 'force-dynamic';
+export interface SubmitReviewResult {
+  ok: boolean;
+  errorKind?: 'invalid_rating' | 'card_not_found' | 'persist_failed' | 'unauthenticated';
+}
 
-const PAGE_SIZE = 20;
+export async function submitReview(cardId: string, rating: number): Promise<SubmitReviewResult> {
+  // Reject malformed ratings BEFORE any DB call (defense in depth — fn also checks).
+  if (!isValidRating(rating)) {
+    counter('review.rating.rejected', { reason: 'invalid_rating' });
+    return { ok: false, errorKind: 'invalid_rating' };
+  }
+  // UUID v4 shape check — Supabase will reject non-UUIDs with a 22P02 anyway,
+  // but cheap to short-circuit + avoid leaking PostgresError noise into logs.
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(cardId)) {
+    counter('review.rating.rejected', { reason: 'invalid_card_id' });
+    return { ok: false, errorKind: 'invalid_rating' };
+  }
 
-export default async function ReviewPage() {
   const rls = await supabaseForRequest();
   const { data: { user } } = await rls.auth.getUser();
-  if (!user) redirect('/auth');
-
-  // /review page-load: 1 supabase select per request, no LLM calls. Free.
-  // PII DISCIPLINE: srs_cards.question/answer are LLM output derived from
-  // user PDFs (COMMENT ON COLUMN confirms). NEVER log them on ANY path,
-  // including error paths below — only log error.name + a bounded code.
-  const { data: cards, error } = await rls
-    .from('srs_cards')
-    .select('id, question, answer, due_at, created_at')
-    .order('created_at', { ascending: false })
-    .limit(PAGE_SIZE);
-
-  if (error) {
-    // PostgREST error — network, RLS misconfigure, or transient. We
-    // render a user-friendly banner instead of the Next.js default 500.
-    // Logged fields are deliberately narrow: error class name + code +
-    // user_id (for support correlation). No card content. No message —
-    // some Supabase error messages echo the query text which can leak
-    // column names; `error.name` + `error.code` are grep-stable and safe.
-    console.error('[/review] load_failed', {
-      errorName: error.name ?? 'UnknownError',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- supabase error untyped
-      code: (error as any)?.code ?? null,
-      user_id: user.id,
-    });
-    counter('review.page.load_failed', { user_id: user.id });
-    return (
-      <main>
-        <h1 className="text-2xl font-semibold text-brand-900 mb-6">
-          {t('review.heading')}
-        </h1>
-        <p role="alert" className="text-danger">
-          {t('review.load_error')}
-        </p>
-      </main>
-    );
+  if (!user) {
+    // Don't redirect from a server action — return so the client can navigate.
+    return { ok: false, errorKind: 'unauthenticated' };
   }
 
-  // Narrow the row shape to what the client component renders. We never
-  // hand SrsCard.user_id / cohort_id over the wire — RLS already gated the
-  // read, and the client doesn't need them.
-  type DeckCard = Pick<SrsCard, 'id' | 'question' | 'answer'>;
-  const deckCards: DeckCard[] = (cards ?? []).map((c) => ({
-    id: c.id,
-    question: c.question,
-    answer: c.answer,
-  }));
+  // Load the card's current state (RLS-scoped). If the user doesn't own it
+  // OR it doesn't exist, the select returns null/error → card_not_found.
+  const { data: card, error: loadErr } = await rls
+    .from('srs_cards')
+    .select('id, fsrs_state')
+    .eq('id', cardId)
+    .single();
+  if (loadErr || !card) {
+    console.error('[/review submitReview] card_load_failed', {
+      errorName: loadErr?.name ?? 'NotFound',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- supabase error untyped
+      code: (loadErr as any)?.code ?? null,
+      user_id: user.id,
+      card_id: cardId,
+    });
+    counter('review.rating.failed', { reason: 'card_not_found' });
+    return { ok: false, errorKind: 'card_not_found' };
+  }
 
-  counter('review.page.viewed', { user_id: user.id, card_count: deckCards.length });
+  // Compute next state. fsrs_state may be {} for a never-reviewed card —
+  // emptyFsrsState() initializes the FSRS-5 starting point.
+  const currentState =
+    Object.keys(card.fsrs_state ?? {}).length === 0
+      ? emptyFsrsState()
+      : (card.fsrs_state as FsrsCardState);
 
-  return (
-    <main>
-      <h1 className="text-2xl font-semibold text-brand-900 mb-6">
-        {t('review.heading')}
-      </h1>
-      <ReviewDeck cards={deckCards} emptyCopy={t('review.empty')} />
-    </main>
-  );
+  const { state: next, due } = nextState(currentState, rating as RatingValue);
+
+  // Persist atomically via the SQL function.
+  const { error: rpcErr } = await rls.rpc('fn_review_card', {
+    p_card_id: cardId,
+    p_rating: rating,
+    p_next_state: next,
+    p_due_at: due.toISOString(),
+    p_prev_state: currentState,
+  });
+  if (rpcErr) {
+    console.error('[/review submitReview] persist_failed', {
+      errorName: rpcErr.name ?? 'UnknownError',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- supabase error untyped
+      code: (rpcErr as any)?.code ?? null,
+      user_id: user.id,
+      card_id: cardId,
+    });
+    counter('review.rating.failed', { reason: 'persist_failed' });
+    return { ok: false, errorKind: 'persist_failed' };
+  }
+
+  counter('review.rating.submitted', {
+    user_id: user.id,
+    rating: String(rating),
+    is_new_card: currentState.state === 0 ? 'true' : 'false',
+  });
+  return { ok: true };
 }
 ```
 
-**Why prefer Supabase's `{ data, error }` branch over `try/catch`:** `supabase-js` wraps PostgREST errors into the tuple rather than throwing. A `try/catch` would only catch network-level failures (fetch throws), leaving the common case — e.g., an RLS misconfigure returning `{ data: null, error: {...} }` — unhandled. Branching on `error` covers both: network errors surface in the `error` field via the client's internal catch. If a new failure mode is found in practice, a top-level `try/catch` is a one-line addition.
+**PII discipline (per CLAUDE.md non-negotiables + the new rebuttal protocol):** error logs include `errorName` + `code` + `user_id` + `card_id` only — never card content, never `error.message` (which can echo query/row text). Counter labels: `user_id`, `card_id` (UUIDs, pseudonyms not PII), `rating` (small int), `is_new_card` (boolean). Card content is NEVER a label.
 
-**Why server component:** auth check + RLS read happen on the server (matches the dashboard pattern). The cookie-write Proxy from `supabaseForRequest` works in Server Components (read-only path; the no-op cookie writes do not halt — see `apps/web/lib/supabase.ts:96-104` "expected RSC context" branch).
+### D. Client wiring — `apps/web/app/review/ReviewDeck.tsx` extension
 
-**Why pre-narrow to `DeckCard`:** never serialize `user_id` / `cohort_id` to client props. Server-component → client-component prop boundary is a privilege boundary. RLS already enforces server-side scoping; the client truly only needs `{id, question, answer}`.
-
-### B. Client Component — `apps/web/app/review/ReviewDeck.tsx`
+Add 4 rating buttons after the existing reveal button. They render only when `revealed === true` and `pendingRating === false`. On click, fire the server action; on success, advance via existing `handleNext`; on failure, surface a toast/alert via the existing `aria-live` region.
 
 ```ts
-'use client';
+// Inside ReviewDeck component, after existing state:
+const [pendingRating, setPendingRating] = useState(false);
+const [ratingError, setRatingError] = useState<string | null>(null);
 
-import { useEffect, useRef, useState } from 'react';
-import { counter } from '@llmwiki/lib-metrics';
-import { t } from '../../lib/i18n';
-
-interface DeckCard {
-  id: string;
-  question: string;
-  answer: string;
-}
-
-interface Props {
-  cards: ReadonlyArray<DeckCard>;
-  emptyCopy: string;
-}
-
-export function ReviewDeck({ cards, emptyCopy }: Props) {
-  const [index, setIndex] = useState(0);
-  const [revealed, setRevealed] = useState(false);
-  const headingRef = useRef<HTMLHeadingElement>(null);
-  // a11y r1 fold: skip the focus-move on the very first render so the
-  // page-load doesn't yank focus from wherever the browser put it. Move
-  // focus only on subsequent index changes (i.e., user clicked "Next").
-  const firstRender = useRef(true);
-
-  useEffect(() => {
-    if (firstRender.current) {
-      firstRender.current = false;
+const handleRate = async (rating: 1 | 2 | 3 | 4) => {
+  if (pendingRating) return; // Double-click guard.
+  setPendingRating(true);
+  setRatingError(null);
+  try {
+    const result = await submitReview(card.id, rating);
+    if (!result.ok) {
+      setRatingError(t('review.rating_error'));
+      setPendingRating(false);
       return;
     }
-    headingRef.current?.focus();
-  }, [index]);
-
-  if (cards.length === 0) {
-    return <p className="text-brand-700">{emptyCopy}</p>;
+    counter('review.card.rated', { rating: String(rating) });
+    handleNext(); // Advances + re-hides answer.
+    setPendingRating(false);
+  } catch {
+    // Server action threw (network, etc.). Don't log error.message — could
+    // contain serialized server state.
+    setRatingError(t('review.rating_error'));
+    setPendingRating(false);
   }
-
-  const card = cards[index];
-  const atEnd = index >= cards.length - 1;
-
-  const handleReveal = () => {
-    setRevealed((r) => {
-      // Only count REVEAL events (false → true), not hide-toggles.
-      if (!r) counter('review.card.revealed', { card_id: card.id });
-      return !r;
-    });
-  };
-  const handleNext = () => {
-    if (atEnd) return;
-    setIndex((i) => i + 1);
-    setRevealed(false);
-  };
-
-  return (
-    <section aria-labelledby="card-heading" className="max-w-xl">
-      {/* tabIndex=-1 makes the heading programmatically focusable so the
-          useEffect above can move focus to it on next-card. The sr-only
-          class keeps it visually hidden; AT users hear "Card N of M". */}
-      <h2 id="card-heading" ref={headingRef} tabIndex={-1} className="sr-only">
-        Card {index + 1} of {cards.length}
-      </h2>
-
-      <div className="border border-brand-100 rounded-md p-6 bg-white">
-        {/* Plain-text node: React escapes HTML by default. NEVER use
-            dangerouslySetInnerHTML on these fields — see issue #38 +
-            COMMENT ON COLUMN srs_cards.question. */}
-        <p className="text-brand-900 text-lg mb-4 whitespace-pre-wrap">
-          {card.question}
-        </p>
-
-        <div aria-live="polite" aria-atomic="true">
-          {revealed && (
-            <p className="text-brand-900 mt-4 pt-4 border-t border-brand-100 whitespace-pre-wrap">
-              {/* Same plain-text guarantee. */}
-              {card.answer}
-            </p>
-          )}
-        </div>
-      </div>
-
-      <div className="mt-4 flex gap-2">
-        <button
-          type="button"
-          onClick={handleReveal}
-          aria-pressed={revealed}
-          className="bg-brand-900 text-white px-4 py-2 rounded-md min-h-[44px]"
-        >
-          {revealed ? t('review.hide_answer') : t('review.show_answer')}
-        </button>
-        <button
-          type="button"
-          onClick={handleNext}
-          disabled={atEnd}
-          className="bg-white text-brand-900 border border-brand-100 px-4 py-2 rounded-md min-h-[44px] disabled:bg-brand-50 disabled:cursor-not-allowed"
-        >
-          Next card
-        </button>
-      </div>
-
-      <p className="mt-2 text-sm text-brand-700">
-        {index + 1} / {cards.length}
-      </p>
-    </section>
-  );
-}
-```
-
-### C. XSS-safety test pattern
-
-```ts
-// apps/web/components/ReviewDeck.test.tsx
-import { describe, it, expect } from 'vitest';
-import { renderToStaticMarkup } from 'react-dom/server';
-import { ReviewDeck } from '../app/review/ReviewDeck';
-
-describe('ReviewDeck XSS safety (issue #38)', () => {
-  it('escapes a script-tag payload in question', () => {
-    const html = renderToStaticMarkup(
-      <ReviewDeck
-        cards={[{ id: '1', question: '<script>alert(1)</script>', answer: 'x' }]}
-        emptyCopy="empty"
-      />,
-    );
-    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
-    expect(html).not.toContain('<script>alert(1)</script>');
-  });
-
-  it('does not leak the answer markup before reveal', () => {
-    const html = renderToStaticMarkup(
-      <ReviewDeck
-        cards={[{ id: '1', question: 'q', answer: '<script>alert(2)</script>' }]}
-        emptyCopy="empty"
-      />,
-    );
-    // Answer block only renders when revealed=true; default state is
-    // unrevealed, so neither the raw nor the escaped payload should appear.
-    expect(html).not.toContain('<script>alert(2)</script>');
-    expect(html).not.toContain('alert(2)');
-  });
-
-  // Interaction tests (reveal toggle, next-card index, empty state) use
-  // the same renderToStaticMarkup pattern with a small <ReviewDeck>
-  // wrapper that pre-seeds state via initial props passed through a
-  // `__testInitial` prop guarded with a one-line justification, OR
-  // alternatively re-renders after a useState mutation by testing the
-  // pure handler functions extracted from the component body. Pick one
-  // approach in implementation; council can flag preference.
-});
-```
-
-**Why `renderToStaticMarkup` instead of `@testing-library/react`:** vitest env is `node` (`apps/web/vitest.config.ts:8`); jsdom is not configured. Adding jsdom + testing-library is a 2-package new-runtime-dep change that needs its own justification. `renderToStaticMarkup` exists in `react-dom/server` (`react-dom@^19` is already in `apps/web/package.json`). Sufficient to verify the XSS non-negotiable: React's text-node default escapes the payload at server-render time. The same escaping applies on the client — React's renderer uses the same text-escaping path.
-
-**Council may push back on this and require jsdom + testing-library for stronger interaction-level tests.** That's a fair ask; if so, fold by adding `jsdom` + `@testing-library/react` + `@testing-library/jest-dom` and rewriting the interaction tests with `render()` + `userEvent`. New runtime deps trigger the standard cost-posture check (none — dev-only). Open question for council: is the `renderToStaticMarkup` proof of XSS-safety sufficient, or does the interaction surface (toggle / next-card) need DOM-level assertion?
-
-### D. i18n keys
-
-Add to `apps/web/lib/i18n.ts`:
-
-```ts
-type Key =
-  | ...existing...
-  | 'review.heading'
-  | 'review.empty'
-  | 'review.show_answer'
-  | 'review.hide_answer';
-
-const STRINGS: Record<Key, string> = {
-  ...,
-  'review.heading': 'Review',
-  'review.empty': 'No flashcards yet. Upload a PDF to generate flashcards.',
-  'review.show_answer': 'Show answer',
-  'review.hide_answer': 'Hide answer',
-  'review.load_error': "Couldn't load your flashcards. Please refresh in a moment.",
 };
 ```
 
-### E. Accessibility
+```tsx
+// JSX additions, rendered only when revealed:
+{revealed && (
+  <div className="mt-4 flex gap-2 flex-wrap" role="group" aria-label="Rate this card">
+    <button type="button" onClick={() => handleRate(1)} disabled={pendingRating}
+      className="bg-danger text-white px-4 py-2 rounded-md min-h-[44px]">
+      {t('review.rating.again')}
+    </button>
+    <button type="button" onClick={() => handleRate(2)} disabled={pendingRating}
+      className="bg-warning text-brand-900 px-4 py-2 rounded-md min-h-[44px]">
+      {t('review.rating.hard')}
+    </button>
+    <button type="button" onClick={() => handleRate(3)} disabled={pendingRating}
+      className="bg-success text-white px-4 py-2 rounded-md min-h-[44px]">
+      {t('review.rating.good')}
+    </button>
+    <button type="button" onClick={() => handleRate(4)} disabled={pendingRating}
+      className="bg-brand-900 text-white px-4 py-2 rounded-md min-h-[44px]">
+      {t('review.rating.easy')}
+    </button>
+  </div>
+)}
+{ratingError && (
+  <p role="alert" className="mt-2 text-danger text-sm">{ratingError}</p>
+)}
+```
 
-- `aria-live="polite"` on the answer container so screen readers announce reveal without interrupting.
-- `aria-pressed` on the reveal button so the toggle state is exposed.
-- `min-h-[44px]` on both buttons matches the existing dashboard pattern (target-size).
-- Card heading (`Card N of M`) is `sr-only` AND `tabIndex={-1}` so the `useEffect` can move focus to it on next-card. AT users hear "Card N of M" announced; visual focus is invisible (sr-only, no outline interference).
-- `useEffect` skips the focus move on first render — page-load doesn't yank focus from the browser's default landing spot.
-- Color tokens are existing `brand-*` / `danger` from `globals.css` — already palette-checked by `tests/a11y/smoke.spec.ts` for contrast.
-- `whitespace-pre-wrap` preserves linebreaks Claude emits in long-form answers (mirrors how the prompt was tuned in `packages/prompts/src/flashcard-gen/v1.md`).
+**a11y:**
+- `role="group"` + `aria-label="Rate this card"` so screen readers announce the rating cluster as a unit.
+- `disabled={pendingRating}` prevents double-submit and conveys state to AT.
+- `min-h-[44px]` on every rating button (touch target).
+- Color tokens: `bg-danger` (Again), `bg-warning` (Hard), `bg-success` (Good), `bg-brand-900` (Easy). All exist in `globals.css`; contrast verified by the existing `axe-core` smoke test (extend the smoke spec to include the rating chrome).
+- The "Next card" button is REPLACED by the 4 rating buttons during the rated phase — once a card is rated, we auto-advance, so a separate "Next" is unnecessary in the rated state. The existing "Next card" button remains visible WHEN NOT REVEALED (lets the user skip a card without rating it).
 
-### F. Route-level test (`apps/web/tests/unit/review-page.test.ts`)
+### E. i18n keys
 
-Mirrors `auth-callback-route.test.ts` shape:
-
-- Stub `next/navigation`'s `redirect` with `vi.fn()` that throws (Next's actual behavior).
-- Stub `supabaseForRequest` to return a builder whose `.auth.getUser()` returns `{ data: { user: null } }`; assert `redirect('/auth')` was called.
-- Stub returning a real user; assert the chain `from('srs_cards').select(...).order('created_at',{ascending:false}).limit(20)` was called against the RLS-scoped client (NOT `supabaseService`).
-- Assert no call to `supabaseService` from the page (RLS-only path; service-role would bypass cohort isolation and is forbidden for this read).
-- **Bugs r1 fold:** stub the select to return `{ data: null, error: { name: 'PostgresError', code: '42P01', message: 'card body sample text that MUST NOT be logged' } }`; assert (a) the page renders the `review.load_error` copy, (b) `console.error` is called with `errorName + code + user_id` only — assert the spied call args do NOT contain the substring "card body sample text" or any portion of the error message, (c) `counter('review.page.load_failed', ...)` was called.
-- **Bugs r1 fold:** stub the select to return cards including `{ id, question: '<script>alert(1)</script>', answer: 'x' }`; assert `console.error` was NOT called for any non-error path, AND assert `counter` was called with `review.page.viewed` and `card_count` matching the stubbed array length — but never with the card content (positive assertion: counter labels' values do not include the script payload).
+```ts
+'review.rating.again': 'Again',
+'review.rating.hard': 'Hard',
+'review.rating.good': 'Good',
+'review.rating.easy': 'Easy',
+'review.rating_error': "Couldn't save your rating. Please try again.",
+'review.rating_pending': 'Saving…',
+```
 
 ## Non-negotiables (must hold; council will not override)
 
-- **No `dangerouslySetInnerHTML` on `srs_cards.question` or `srs_cards.answer`.** XSS surface; mandated by issue #38 + the migration's `COMMENT ON COLUMN`.
-- **RLS-only read.** Use `supabaseForRequest`, never `supabaseService`. The `/review` page is a per-user surface; service-role would bypass `srs_cards_own` policy at `supabase/migrations/20260417000002_rls_policies.sql:118-121`.
-- **Auth redirect on unauthenticated.** Match `apps/web/app/page.tsx:11-14` exactly; do not render an empty page or a "please sign in" message in-place (existing UX contract).
-- **Plain-text rendering.** No markdown library, no HTML parsing. v0 is text-node-only.
-- **Server → client prop boundary narrows to `{id, question, answer}`.** Never serialize `user_id` / `cohort_id` to the client.
-- **XSS-payload unit test exists and passes.** Acceptance-criteria checkbox in issue #38.
-- **PII discipline on logging (council r1 security non-negotiable):** `srs_cards.question` and `srs_cards.answer` MUST NOT be logged on any path. Error logs include only `errorName`, `code`, and `user_id` — never the message body, since some PostgREST messages echo query text. A test asserts the error-path log args do not contain stubbed message content. Comment at the page-load callsite codifies the rule.
-- **Graceful error UI on query failure (council r1 bugs ask):** `{ error }` branch renders the `review.load_error` banner and increments `review.page.load_failed`; never falls through to the Next.js 500.
-- **Focus management on next-card (council r1 a11y ask):** focus moves to the sr-only card heading on `index` change (not first render), so screen-reader users hear the new card position.
+- **Atomicity:** card state update + review_history insert MUST be in a single Postgres transaction. The `fn_review_card` SQL function is the boundary.
+- **`security invoker` on `fn_review_card`:** never `security definer`; `auth.uid()` must flow through to RLS.
+- **Rating validation BEFORE DB call:** server action rejects non-`{1,2,3,4}` ratings + non-UUID `cardId` shapes before any Supabase call. Defense in depth: SQL function also rejects, but the server-action rejection is the cheap-and-loud path.
+- **PII discipline on logging:** server action error logs include `errorName` + `code` + `user_id` + `card_id` only; never `error.message`, never card content. ErrorBoundary log shape preserved.
+- **No service-role client in the rating path:** all reads + the RPC call go through `supabaseForRequest`. RLS is the security model.
+- **`fsrs_state = {}` is treated as "new card" and initialized via `emptyFsrsState()`:** never passed directly to `nextState()` (would crash on missing fields).
+- **Auth gate:** unauthenticated server action calls return `{ok: false, errorKind: 'unauthenticated'}`; client navigates to `/auth`. NEVER mutate without an authenticated `user.id`.
 
-## Tests
+## Tests (per the new rebuttal-protocol failure-mode requirement)
 
-- `apps/web/components/ReviewDeck.test.tsx` — XSS escape (question + answer), empty state, reveal toggle behavior, next-card behavior, reveal-counter only fires on false→true (not hide). Target ≥7 cases.
-- `apps/web/tests/unit/review-page.test.ts` — auth redirect, RLS-only read, no service-role call, error-branch renders banner + logs PII-safe shape, view-counter fires on success. Target ≥6 cases.
-- `apps/web/tests/a11y/smoke.spec.ts` — extend with a static-HTML pass that includes a representative card layout (one card div + two buttons + sr-only heading). Verifies palette + target-size for the new surface ahead of the dev-server CI integration.
+Each component has BOTH happy-path AND failure-mode coverage. Failure-mode coverage is the proof per `CLAUDE.md` §"Rebutting council findings" rule #2.
 
-`npm run lint`, `npm run typecheck`, `npm test` all pass for `apps/web`.
+### `packages/lib/srs/src/index.test.ts` (algorithm contract; ~12 tests)
+
+- **Happy path:**
+  - `emptyFsrsState()` produces a state with `state: 0, reps: 0, lapses: 0`.
+  - `nextState(empty, RATING_GOOD)` advances `reps` to 1 and sets `due` in the future.
+- **Failure modes:**
+  - `nextState(empty, RATING_AGAIN)` keeps `reps` low + sets `due` very soon (< 1 day).
+  - `nextState(reviewed, RATING_AGAIN)` increments `lapses` (the algorithm's lapse counter).
+  - **Ordering invariant:** for any state, `due(EASY) > due(GOOD) > due(HARD) > due(AGAIN)`. Property test across 20 random states. **This is the failure-mode proof for the algorithm: if the math breaks, ordering breaks.**
+  - `isValidRating(0)`, `isValidRating(5)`, `isValidRating('3')`, `isValidRating(null)`, `isValidRating(undefined)` all return false. `isValidRating(1..4)` all return true.
+  - `nextState(state, 5 as RatingValue)` — passing an invalid rating that's been (incorrectly) cast — does NOT silently produce a result; either throws or returns a sentinel. (ts-fsrs behavior TBD; test pins the contract whichever way it goes.)
+  - `nextState` is determinism-tolerant: re-calling with same args + same `now` produces the same `state` shape, same `reps`/`lapses`/`state`. Fuzz-on may vary `due` by ±a small fraction; test asserts ordering, not exact value.
+
+### `apps/web/app/review/actions.test.ts` (server-action behavior; ~10 tests)
+
+- **Happy path:**
+  - `submitReview(validId, 3)` with authed user + valid card → `{ok: true}` + `fn_review_card` RPC called with correct args + `review.rating.submitted` counter fired.
+  - `submitReview` on a never-reviewed card (`fsrs_state = {}`) → `nextState` is called with `emptyFsrsState()`, not `{}` directly.
+- **Failure modes (the rebuttal-protocol failure-mode proof for this surface):**
+  - `submitReview(validId, 0)` → `{ok: false, errorKind: 'invalid_rating'}` + `review.rating.rejected` counter + NO Supabase calls made.
+  - `submitReview(validId, 5)` → same.
+  - `submitReview('not-a-uuid', 3)` → `{ok: false, errorKind: 'invalid_rating'}` + counter + no Supabase calls.
+  - `submitReview(validId, 3)` with no auth user → `{ok: false, errorKind: 'unauthenticated'}` + no `from('srs_cards')` call.
+  - Card not owned by user (RLS blocks the select → returns null) → `{ok: false, errorKind: 'card_not_found'}` + log shape verified PII-safe (negative-assert sentinel string).
+  - `fn_review_card` RPC returns error → `{ok: false, errorKind: 'persist_failed'}` + log shape PII-safe + `review.rating.failed` counter with `reason: 'persist_failed'`.
+  - **PII negative assertion:** stub the RPC to return an error with `message: 'CARDCONTENT_SECRET_DO_NOT_LOG: relation x'` — assert `JSON.stringify(spy.mock.calls)` does NOT contain the sentinel.
+  - Counter labels never include card content (negative assert).
+
+### `apps/web/components/ReviewDeck.test.tsx` (UI integration; ~6 new tests)
+
+- Rating buttons NOT rendered when `revealed === false` (assert markup absence).
+- Rating buttons rendered when `revealed === true`.
+- Rating buttons have `min-h-[44px]` + `role="group"` + `aria-label`.
+- Clicking Again/Hard/Good/Easy fires `submitReview` with the right rating value (mock the action).
+- On `{ok: false}`, error banner renders with `role="alert"`.
+- On `{ok: true}`, advances to next card (index increments + answer re-hides).
+- **Failure-mode:** double-click on a rating button doesn't fire `submitReview` twice (`pendingRating` guard).
+
+### `supabase/tests/fn_review_card.sql` (pgTAP; non-load-bearing per #7)
+
+- Function signature exists.
+- User A cannot review User B's card (returns RLS error).
+- Invalid rating raises `22023`.
+- Atomicity: when called inside a savepoint that we then roll back, neither table changes (proves the function is participating in the transaction).
+
+**Note per the new rebuttal-protocol rule:** the pgTAP suite is `continue-on-error` and known-flaky (#7). It cannot be cited as the proof for the RLS rebuttal protocol. The `supabaseForRequest` server-action tests above ARE the consistently-passing failure-mode proof for the `card_not_found` (RLS-blocked) path.
 
 ## Risks
 
-1. **`renderToStaticMarkup` may not satisfy council's "interaction tests" bar.** Fold path: add `jsdom` + `@testing-library/react` + `@testing-library/jest-dom` (dev-deps only; no runtime cost), switch test environment to `jsdom` for `*.test.tsx` only (`environmentMatchGlobs` in vitest config), rewrite interaction tests with `render()` + `userEvent`. Defer until council asks.
-2. **Server Component cookie-write Proxy in `/review` page context.** The `supabaseForRequest` Proxy logs nothing on its own (`apps/web/lib/supabase.ts:65-72`); SC context throws are swallowed silently per the "expected RSC context" branch. No new behavior needed. Tested at `supabase.test.ts`.
-3. **`due_at` filter omitted in v0.** Cards never become "due-only" in this PR; user sees all of their cards. Acceptable v0 trade — FSRS scoring is the trigger for due-filtering. Add the filter the same week the rating UI lands so the partial index pays off.
-4. **Card text length unbounded.** `whitespace-pre-wrap` + `max-w-xl` handles long cards visually; no explicit truncation. The flashcard prompt (`packages/prompts/src/flashcard-gen/v1.md`) targets concise cards and Claude's output rarely exceeds ~200 chars per side, but a malicious prompt-injected PDF could produce arbitrarily long output. Considered acceptable for v0 — long cards degrade UX, do not crash the page.
-5. **No realtime / optimistic updates.** A user generating new flashcards via PDF upload then visiting `/review` requires a manual refresh. Acceptable v0; Realtime is a separate slice (the dashboard already uses it for `ingestion_jobs` via `IngestionStatusTable`).
-6. **Null `question`/`answer` placeholder rendering — REBUTTED, no fold (council r1 bugs ask).** Council r1 asked for a `[No content]` placeholder when either field is null. The schema at `supabase/migrations/20260417000001_initial_schema.sql:152-153` declares both columns `text not null`; the column-level constraint is enforced at write time by Postgres and at row time by `supabase-js`'s typed inserts. A null arriving at this read would mean the constraint was bypassed (impossible without a manual `ALTER TABLE`) — defensive rendering for a schema-impossible value is dead code. **Action:** none. The plan's TypeScript types (`SrsCard.question: string`, not `string | null` at `packages/db/src/types.ts:92-93`) reflect the schema and the code naturally cannot encounter the null path. If a future migration relaxes `not null`, the type widens and the compiler forces a placeholder decision then — which is the correct moment for it.
-
-## Metrics (council r1 product fold)
-
-Per CLAUDE.md "Cost posture" + the council r1 product persona kill criterion:
-
-- `review.page.viewed{user_id, card_count}` — fired once per successful page load. Powers engagement floor.
-- `review.page.load_failed{user_id}` — fired on the `error`-branch in `ReviewPage`. Should be ≪ 1% of `viewed` if Supabase is healthy.
-- `review.card.revealed{card_id}` — fired only on the false→true transition of the reveal toggle (not on hide). Direct measure of card engagement; the kill criterion below reads off this counter.
-
-**Kill criterion** (per council r1 product): zero `review.card.revealed` events from the active cohort one week post-merge → flashcard-product hypothesis is invalid → revisit prompt + UX before adding FSRS scoring.
-
-`user_id` is included as a label for support correlation; `card_id` is the `srs_cards.id` UUID — neither is PII (they are pseudonyms generated server-side). Card content is NEVER a label.
+1. **`ts-fsrs` runtime dep adds bundle size.** ~10kb min+gz. The lib is server-side only (the algorithm runs in the server action), so the client bundle is unaffected. `ts-fsrs` only needs to be installed in the workspace package that imports it (`packages/lib/srs/`). Confirm via bundle-analyzer post-merge.
+2. **Algorithm-correctness risk if `ts-fsrs` has bugs.** Mitigated by the ordering-invariant property test in §Tests (if math breaks, ordering breaks). FSRS-5 is a well-published spec; lib is the canonical TypeScript port.
+3. **`security invoker` + RLS interaction subtleties.** The function's `select user_id into v_user_id` runs under the caller's auth context — if RLS blocks the select, `v_user_id` is null and we raise `42501`. Tested via the `card_not_found` server-action test path (consistently passing).
+4. **Rapid-rating race conditions.** User clicks Again then immediately Good for the same card before the first server action returns. Mitigated by `pendingRating` state in the client + `useState` updater discipline. Tested.
+5. **`ts-fsrs` API stability.** Pin to an exact version in `package.json`; document in a comment that bumps need a council round (algorithm changes between FSRS-4 and FSRS-5 mattered; future bumps could too).
+6. **Migration ordering.** New migration `20260424000001` runs after the existing `20260422000001_srs_cards_unique.sql`. Idempotent (uses `create or replace function`). Safe to re-run.
+7. **No "undo" for an accidental rating.** Acknowledged out-of-scope; the lapse counter recovers from one wrong click via the next review's Again rating. Real undo is a UX feature for v2.
 
 ## Cost
 
-Zero net cost. No new external API calls, no new model usage, no new runtime dependencies. The route is a single Postgres `select` per page-load (RLS-scoped, indexed on `(user_id, due_at)` partial — though this query doesn't use that index since `due_at` filter is omitted; falls back to `srs_cards_note_id_idx` + table scan within the user's cards subset, which is fine at v0 cardinality).
+Zero net runtime cost. The `submitReview` server action makes 1 Supabase select + 1 RPC per rating click. The FSRS algorithm runs in the server action (no LLM call). Estimate per active user: ~50 ratings/week × 4 ops/rating × $0 (covered by Supabase base fee) = $0/user/month.
 
-Per-callsite cost annotation (CLAUDE.md "Cost posture" rule) added at the page-load query: `// /review page-load: 1 supabase select per request, no LLM calls. Free.`
+`ts-fsrs` is a one-time dep cost (no per-call cost). Bundle size: server-side only, no impact on client.
 
 ## Out of scope (for the avoidance of doubt)
 
-- FSRS scoring + `review_history` writes.
-- Due-now filter.
-- Markdown rendering.
-- Card edit / delete.
-- Keyboard shortcuts.
-- Realtime subscription.
-- Bulk-review session.
-- Mobile gesture support beyond the 44px-target buttons.
+- Due-now filter on `/review` initial query (separate ticket; comes after rating UX is validated).
+- Per-user FSRS parameter tuning.
+- Multi-deck management / Anki-style organization.
+- Review session boundaries.
+- Heatmap / streak tracking.
+- Undo last review.
+- Mobile gesture rating (swipe).
+- Keyboard shortcuts (1/2/3/4) — small follow-up.
 
-## Acceptance criteria (from issue #38, expanded)
+## Acceptance criteria
 
-- [ ] Route exists at `/review`.
-- [ ] Authenticated user sees own cards; unauthenticated user redirects to `/auth`.
-- [ ] Empty state copy renders for zero cards.
-- [ ] No `dangerouslySetInnerHTML` on `question` or `answer` (grep-verifiable).
-- [ ] XSS unit test with `<script>alert(1)</script>` payload passes (escaped output).
-- [ ] WCAG AA contrast on the card surface (existing `brand-*` palette; smoke test extended).
-- [ ] `aria-live` region announces show-answer.
-- [ ] `aria-pressed` exposes reveal-button toggle state.
-- [ ] All buttons ≥44px touch target.
-- [ ] Focus moves to card heading on next-card (not on first render).
-- [ ] Error branch renders the `review.load_error` banner; no Next.js 500 page on Supabase failure.
-- [ ] `console.error` on the error path includes `errorName` + `code` + `user_id` only — never card content (test asserts negative).
-- [ ] `review.page.viewed`, `review.page.load_failed`, `review.card.revealed` counters fire on their respective paths.
+- [ ] User can click Again/Hard/Good/Easy after revealing an answer; click is disabled when answer is hidden.
+- [ ] Click triggers `submitReview` server action; response advances to next card on success.
+- [ ] `srs_cards.fsrs_state` + `srs_cards.due_at` updated atomically with `review_history` insert.
+- [ ] Never-reviewed card (`fsrs_state = {}`) initializes via `emptyFsrsState()` on first review.
+- [ ] Unauthenticated rating attempts return `unauthenticated` error kind, no DB writes.
+- [ ] User cannot review another user's card (RLS blocks via `security invoker`).
+- [ ] Invalid rating values rejected before any DB call.
+- [ ] Server-action error logs are PII-safe (failure-mode test asserts negatively against sentinel).
+- [ ] Counter labels never include card content (failure-mode test asserts negatively).
+- [ ] `ordering invariant` property test passes for FSRS algorithm contract.
+- [ ] All buttons ≥44px touch target, `role="group"` on rating cluster, `aria-label` present.
 - [ ] `npm run lint`, `npm run typecheck`, `npm test` pass.
 - [ ] Council PROCEED on the impl-diff round.
 
 ## Council prompts (anticipated axes)
 
-- **Security:** XSS; service-role leakage; client-prop boundary; RLS coverage.
-- **Bugs:** empty array, single-card boundary (no "next" enabled), reveal-toggle interaction with next-card transitions, screen-reader announcement timing.
-- **Accessibility:** target size, contrast, `aria-live` politeness, focus management on next-card (we don't move focus today; council may ask we do).
-- **Architecture:** Server/Client split, prop-boundary narrowing, force-dynamic on auth-gated route.
-- **Cost:** zero — should sail.
-- **Product:** is plain-text-only the right v0 (vs markdown)? Issue #38 says yes; council can flag for a future revisit.
+- **Security:** `security invoker` choice (not definer); RLS coverage on `fn_review_card`; PII-safe logging; rating validation before DB call.
+- **Bugs:** atomicity boundary (single SQL function vs two client calls); `fsrs_state = {}` new-card branch; double-click guard; rating range validation; concurrent-rating race.
+- **Architecture:** wrapper-package pattern for `ts-fsrs`; server-action vs route-handler choice; SQL-function-as-transaction-boundary pattern.
+- **Cost:** zero runtime — should sail. New runtime dep — council scrutiny on `ts-fsrs` choice vs minimal in-house.
+- **Product:** Again/Hard/Good/Easy is the canonical FSRS rating set; closes the loop.
+- **a11y:** rating button cluster `role="group"` + `aria-label`; pending state announced via `disabled` + `aria-busy`; focus-management when card auto-advances after rating.

--- a/apps/web/app/review/ReviewDeck.tsx
+++ b/apps/web/app/review/ReviewDeck.tsx
@@ -1,16 +1,22 @@
 'use client';
 
 // One-card-at-a-time SRS review surface. Question shown by default;
-// reveal toggle exposes the answer; "Next card" advances the index and
-// re-hides. Plain-text rendering only — both `card.question` and
+// reveal toggle exposes the answer; user rates the card; system
+// auto-advances. Plain-text rendering only — both `card.question` and
 // `card.answer` are LLM-generated from user-uploaded PDFs (see
 // COMMENT ON COLUMN srs_cards.question/answer in migration
 // 20260422000001_srs_cards_unique.sql + issue #38). NEVER use
 // dangerouslySetInnerHTML on these fields. React's default text-node
 // rendering escapes HTML and is the entire XSS mitigation.
+//
+// PR #48 added: 4 rating buttons (Again/Hard/Good/Easy) after answer
+// reveal; submitReview server action with idempotency + optimistic
+// concurrency + Tier E rate-limit; auto-advance via the existing
+// useEffect-on-[index] focus-mgmt seam from PR #42.
 import { useEffect, useRef, useState } from 'react';
 import { counter } from '@llmwiki/lib-metrics';
 import { t } from '../../lib/i18n';
+import { submitReview, type SubmitReviewResult } from './actions';
 
 export interface DeckCard {
   id: string;
@@ -28,6 +34,26 @@ export function nextIndex(current: number, totalCards: number): number {
   return Math.min(current + 1, totalCards - 1);
 }
 
+/**
+ * Generate a UUIDv4 for the rating's idempotency key. crypto.randomUUID
+ * is available in all evergreen browsers + Node 18+. Council r2 bugs
+ * nice-to-have fold (PR #48): an absence guard surfaces a graceful error
+ * instead of crashing on truly ancient browsers.
+ *
+ * Exported so the test asserts:
+ *   1. shape conforms to the server action's UUID validator;
+ *   2. successive calls produce DIFFERENT keys (no accidental key reuse).
+ */
+export function generateIdempotencyKey(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback: returning '' triggers the server action's
+  // invalid_idempotency_key error path — surfaces a "browser unsupported"
+  // UX instead of silently making all retries collapse on one bucket.
+  return '';
+}
+
 interface Props {
   cards: ReadonlyArray<DeckCard>;
   emptyCopy: string;
@@ -36,10 +62,12 @@ interface Props {
 export function ReviewDeck({ cards, emptyCopy }: Props) {
   const [index, setIndex] = useState(0);
   const [revealed, setRevealed] = useState(false);
+  const [pendingRating, setPendingRating] = useState(false);
+  const [ratingError, setRatingError] = useState<string | null>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
   // Skip the focus-move on first render so page-load doesn't yank
   // focus from wherever the browser put it. Move focus only on
-  // subsequent index changes (i.e., user clicked "Next card").
+  // subsequent index changes (i.e., user clicked "Next card" or rated).
   const firstRender = useRef(true);
 
   useEffect(() => {
@@ -50,38 +78,68 @@ export function ReviewDeck({ cards, emptyCopy }: Props) {
     headingRef.current?.focus();
   }, [index]);
 
+  // Council r2 bugs nice-to-have fold: clear stale rating error when the
+  // user navigates to a new card without rating. Otherwise an error from
+  // card N would persist visually onto card N+1.
+  useEffect(() => {
+    setRatingError(null);
+  }, [index]);
+
   if (cards.length === 0) {
     return <p className="text-brand-700">{emptyCopy}</p>;
   }
 
-  // Clamp defensively — useState(0) is the initial value but a future
-  // refactor that mutates the card list out of sync with `index` should
-  // not crash here. This is a belt for the suspenders below.
   const safeIndex = Math.min(index, cards.length - 1);
-  // Non-null assertion: the empty-array branch above returns; safeIndex
-  // is in [0, cards.length-1] by Math.min; under noUncheckedIndexedAccess
+  // Non-null assertion: empty-array branch above returns; safeIndex is
+  // in [0, cards.length-1] by Math.min; under noUncheckedIndexedAccess
   // TS still infers `DeckCard | undefined`. The assertion is justified.
   const card = cards[safeIndex]!;
 
   const handleReveal = () => {
     setRevealed((r) => {
       // Count REVEAL events only (false → true), not hide-toggles.
-      // Powers `review.card.revealed` engagement metric / kill criterion.
       if (!r) counter('review.card.revealed', { card_id: card.id });
       return !r;
     });
   };
 
   const handleNext = () => {
-    // Updater form via the exported `nextIndex` helper (council r2
-    // bugs fold + test seam): a double-click queues two setIndex
-    // calls; the stale `atEnd` check at call time can let both
-    // through, putting `index` past `cards.length - 1`. The clamp in
-    // the updater makes a double-click on the last card a no-op
-    // rather than an out-of-bounds read. The helper is exported so the
-    // unit test asserts the clamp without needing a DOM environment.
     setIndex((i) => nextIndex(i, cards.length));
     setRevealed(false);
+  };
+
+  const handleRate = async (rating: 1 | 2 | 3 | 4) => {
+    if (pendingRating) return; // Double-click guard.
+    setPendingRating(true);
+    setRatingError(null);
+    const idempotencyKey = generateIdempotencyKey();
+    let result: SubmitReviewResult;
+    try {
+      result = await submitReview(card.id, rating, idempotencyKey);
+    } catch (err) {
+      // Network drop / framework error. Don't log error.message — could
+      // contain serialized server state. Log error class only.
+      const errorName = err instanceof Error ? err.name : typeof err;
+      console.error('[ReviewDeck] rating_threw', { errorName });
+      setRatingError(t('review.rating_error'));
+      setPendingRating(false);
+      return;
+    }
+    if (!result.ok) {
+      // Distinct copy for rate-limit so user knows to slow down vs retry.
+      const copyKey =
+        result.errorKind === 'rate_limited'
+          ? 'review.rating_rate_limit_error'
+          : 'review.rating_error';
+      setRatingError(t(copyKey));
+      // Council nice-to-have: PII-safe debug log of bounded enum.
+      console.error('[ReviewDeck] rating_failed', { errorKind: result.errorKind });
+      setPendingRating(false);
+      return;
+    }
+    counter('review.card.rated', { rating: String(rating) });
+    handleNext(); // Advances + re-hides answer + (via useEffect) moves focus.
+    setPendingRating(false);
   };
 
   const atEnd = safeIndex >= cards.length - 1;
@@ -113,26 +171,88 @@ export function ReviewDeck({ cards, emptyCopy }: Props) {
         </div>
       </div>
 
-      <div className="mt-4 flex gap-2">
+      <div className="mt-4 flex gap-2 flex-wrap">
         <button
           type="button"
           onClick={handleReveal}
           aria-pressed={revealed}
-          className="bg-brand-900 text-white px-4 py-2 rounded-md min-h-[44px]"
+          disabled={pendingRating}
+          className="bg-brand-900 text-white px-4 py-2 rounded-md min-h-[44px] disabled:bg-brand-700 disabled:cursor-not-allowed"
         >
           {revealed ? t('review.hide_answer') : t('review.show_answer')}
         </button>
-        <button
-          type="button"
-          onClick={handleNext}
-          disabled={atEnd}
-          className="bg-white text-brand-900 border border-brand-100 px-4 py-2 rounded-md min-h-[44px] disabled:bg-brand-50 disabled:cursor-not-allowed"
-        >
-          {t('review.next_card')}
-        </button>
+        {/* Skip-without-rating button: kept visible whether or not the
+            user has revealed/rated, so they can move past a card. Hidden
+            during pending submit so a click doesn't race the rating. */}
+        {!revealed && (
+          <button
+            type="button"
+            onClick={handleNext}
+            disabled={atEnd || pendingRating}
+            className="bg-white text-brand-900 border border-brand-100 px-4 py-2 rounded-md min-h-[44px] disabled:bg-brand-50 disabled:cursor-not-allowed"
+          >
+            {t('review.next_card')}
+          </button>
+        )}
       </div>
 
-      <p className="mt-2 text-sm text-brand-700">
+      {revealed && (
+        <div
+          className="mt-4 flex gap-2 flex-wrap"
+          role="group"
+          aria-label="Rate this card"
+        >
+          <button
+            type="button"
+            onClick={() => handleRate(1)}
+            disabled={pendingRating}
+            className="bg-danger text-white px-4 py-2 rounded-md min-h-[44px] disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {t('review.rating.again')}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleRate(2)}
+            disabled={pendingRating}
+            className="bg-warning text-brand-900 px-4 py-2 rounded-md min-h-[44px] disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {t('review.rating.hard')}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleRate(3)}
+            disabled={pendingRating}
+            className="bg-success text-white px-4 py-2 rounded-md min-h-[44px] disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {t('review.rating.good')}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleRate(4)}
+            disabled={pendingRating}
+            className="bg-brand-900 text-white px-4 py-2 rounded-md min-h-[44px] disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {t('review.rating.easy')}
+          </button>
+        </div>
+      )}
+
+      {pendingRating && (
+        <p
+          className="mt-2 text-sm text-brand-700"
+          role="status"
+          aria-live="polite"
+        >
+          {t('review.rating_pending')}
+        </p>
+      )}
+      {ratingError && (
+        <p className="mt-2 text-danger text-sm" role="alert">
+          {ratingError}
+        </p>
+      )}
+
+      <p className="mt-4 text-sm text-brand-700">
         {safeIndex + 1} / {cards.length}
       </p>
     </section>

--- a/apps/web/app/review/actions.test.ts
+++ b/apps/web/app/review/actions.test.ts
@@ -1,0 +1,358 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Server-action integration tests for /review submitReview.
+//
+// Non-negotiables this suite enforces (PR #48 plan §Tests + council
+// rounds r1 + r2):
+//
+//   1. [security] Explicit RLS-blocked test: User A cannot review User
+//      B's card (consistently passing here, not just pgTAP per #7).
+//   2. [security] PII-safe error logging: error.message + ZodError
+//      issue.path/.message NEVER appear in console.error args.
+//   3. [security] Tier E rate limit: 30/user/min; 31st fails.
+//   4. [security] Fail-open on RatelimitUnavailableError.
+//   5. [bugs] Idempotency replay: second call with same key is a no-op
+//      success.
+//   6. [bugs] Optimistic concurrency: 40001 from RPC returns
+//      concurrent_update errorKind.
+//   7. [bugs] Malformed fsrs_state returns invalid_state errorKind.
+
+// --- Mocks ----------------------------------------------------------
+
+const getUserMock = vi.fn();
+const fromMock = vi.fn();
+const rpcMock = vi.fn();
+
+vi.mock('../../lib/supabase', () => ({
+  supabaseForRequest: async () => ({
+    auth: { getUser: getUserMock },
+    from: fromMock,
+    rpc: rpcMock,
+  }),
+}));
+
+// Counter spy. We assert which counters fire on each path.
+const counterMock = vi.fn();
+vi.mock('@llmwiki/lib-metrics', () => ({ counter: counterMock }));
+
+// Rate-limiter spy. Mocked so individual tests can drive the tier-E
+// quota-exceeded + unavailable branches without real Upstash.
+const reserveMock = vi.fn();
+vi.mock('@llmwiki/lib-ratelimit', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@llmwiki/lib-ratelimit')>();
+  return {
+    ...actual,
+    makeRatingLimiter: () => ({ reserve: reserveMock }),
+  };
+});
+
+// --- Test fixtures --------------------------------------------------
+
+const TEST_USER = { id: '11111111-1111-1111-1111-111111111111' };
+const TEST_CARD_ID = '22222222-2222-2222-2222-222222222222';
+const VALID_KEY = '33333333-3333-3333-3333-333333333333';
+
+function setSelectSuccess(card: { id: string; fsrs_state: unknown }): void {
+  const singleMock = vi.fn(() => Promise.resolve({ data: card, error: null }));
+  const eqMock = vi.fn(() => ({ single: singleMock }));
+  const selectMock = vi.fn(() => ({ eq: eqMock }));
+  fromMock.mockReturnValue({ select: selectMock });
+}
+
+function setSelectError(error: {
+  name: string;
+  code: string;
+  message: string;
+}): void {
+  const singleMock = vi.fn(() =>
+    Promise.resolve({ data: null, error }),
+  );
+  const eqMock = vi.fn(() => ({ single: singleMock }));
+  const selectMock = vi.fn(() => ({ eq: eqMock }));
+  fromMock.mockReturnValue({ select: selectMock });
+}
+
+function emptyCardRow() {
+  return { id: TEST_CARD_ID, fsrs_state: {} };
+}
+
+// --- Suite ----------------------------------------------------------
+
+describe('/review submitReview server action', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    getUserMock.mockReset();
+    fromMock.mockReset();
+    rpcMock.mockReset();
+    counterMock.mockReset();
+    reserveMock.mockReset();
+    reserveMock.mockResolvedValue(undefined); // default: rate limit allows
+    consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    vi.resetModules();
+  });
+
+  // ===== Input validation (no DB calls on rejection) ==================
+
+  it('rejects rating outside 1..4', async () => {
+    const { submitReview } = await import('./actions');
+    for (const bad of [0, 5, -1, 99, 1.5]) {
+      const result = await submitReview(TEST_CARD_ID, bad, VALID_KEY);
+      expect(result).toEqual({ ok: false, errorKind: 'invalid_rating' });
+    }
+    expect(fromMock).not.toHaveBeenCalled();
+    expect(reserveMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-UUID cardId', async () => {
+    const { submitReview } = await import('./actions');
+    const result = await submitReview('not-a-uuid', 3, VALID_KEY);
+    expect(result).toEqual({ ok: false, errorKind: 'invalid_rating' });
+    expect(fromMock).not.toHaveBeenCalled();
+    expect(reserveMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty / non-UUID idempotencyKey', async () => {
+    const { submitReview } = await import('./actions');
+    const r1 = await submitReview(TEST_CARD_ID, 3, '');
+    expect(r1).toEqual({ ok: false, errorKind: 'invalid_idempotency_key' });
+    const r2 = await submitReview(TEST_CARD_ID, 3, 'not-a-uuid');
+    expect(r2).toEqual({ ok: false, errorKind: 'invalid_idempotency_key' });
+    expect(fromMock).not.toHaveBeenCalled();
+    expect(reserveMock).not.toHaveBeenCalled();
+  });
+
+  // ===== Auth ========================================================
+
+  it('returns unauthenticated when no user; no DB or rate-limit calls', async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+    const { submitReview } = await import('./actions');
+    const result = await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+    expect(result).toEqual({ ok: false, errorKind: 'unauthenticated' });
+    expect(fromMock).not.toHaveBeenCalled();
+    expect(reserveMock).not.toHaveBeenCalled();
+  });
+
+  // ===== Rate limit (Tier E) =========================================
+
+  it('rate_limited: RateLimitExceededError → no DB call', async () => {
+    getUserMock.mockResolvedValue({ data: { user: TEST_USER } });
+    const { RateLimitExceededError } = await import('@llmwiki/lib-ratelimit');
+    reserveMock.mockRejectedValueOnce(
+      new RateLimitExceededError('rating_submits', new Date(Date.now() + 60_000)),
+    );
+    const { submitReview } = await import('./actions');
+    const result = await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+    expect(result).toEqual({ ok: false, errorKind: 'rate_limited' });
+    expect(fromMock).not.toHaveBeenCalled();
+    expect(counterMock).toHaveBeenCalledWith('review.rating.failed', {
+      reason: 'rate_limited',
+      user_id: TEST_USER.id,
+    });
+  });
+
+  it('fail-open on RatelimitUnavailableError: continues to DB', async () => {
+    getUserMock.mockResolvedValue({ data: { user: TEST_USER } });
+    const { RatelimitUnavailableError } = await import('@llmwiki/lib-ratelimit');
+    reserveMock.mockRejectedValueOnce(new RatelimitUnavailableError());
+    setSelectSuccess(emptyCardRow());
+    rpcMock.mockResolvedValue({ error: null });
+
+    const { submitReview } = await import('./actions');
+    const result = await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+    expect(result.ok).toBe(true);
+    expect(fromMock).toHaveBeenCalledWith('srs_cards');
+  });
+
+  // ===== RLS-blocked (council r1 security non-negotiable) ============
+
+  it('RLS blocks card load: User A cannot review User B card → card_not_found', async () => {
+    getUserMock.mockResolvedValue({ data: { user: TEST_USER } });
+    // PostgREST shape when .single() finds 0 rows under RLS is { data: null,
+    // error: { code: 'PGRST116', name: 'PostgresError', message: 'JSON object requested, multiple (or no) rows returned' } }
+    setSelectError({
+      name: 'PostgresError',
+      code: 'PGRST116',
+      message: 'CARDCONTENT_SECRET_DO_NOT_LOG: ...',
+    });
+
+    const { submitReview } = await import('./actions');
+    const result = await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+    expect(result).toEqual({ ok: false, errorKind: 'card_not_found' });
+    expect(rpcMock).not.toHaveBeenCalled();
+
+    // PII-safe log: includes errorName + code + user_id + card_id; NEVER
+    // the message body.
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith('[/review submitReview] card_load_failed', {
+      errorName: 'PostgresError',
+      code: 'PGRST116',
+      user_id: TEST_USER.id,
+      card_id: TEST_CARD_ID,
+    });
+    const serialized = JSON.stringify(consoleSpy.mock.calls);
+    expect(serialized).not.toContain('CARDCONTENT_SECRET_DO_NOT_LOG');
+  });
+
+  // ===== Zod malformed state (council r1 bugs non-negotiable) ========
+
+  it('invalid_state: malformed fsrs_state → ZodError → invalid_state errorKind', async () => {
+    getUserMock.mockResolvedValue({ data: { user: TEST_USER } });
+    // Zod parse will throw on this shape because `due` is a number not ISO.
+    // The PII sentinel below is in a value; we assert the log doesn't echo it.
+    setSelectSuccess({
+      id: TEST_CARD_ID,
+      fsrs_state: { due: 12345, message: 'PII_SENTINEL_DO_NOT_LOG' },
+    });
+
+    const { submitReview } = await import('./actions');
+    const result = await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+    expect(result).toEqual({ ok: false, errorKind: 'invalid_state' });
+    expect(rpcMock).not.toHaveBeenCalled();
+
+    // Log shape: errorName + issueCount (number) + user_id + card_id only.
+    // Specifically NOT issue.path or issue.message — those could include
+    // the malformed field's value.
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[/review submitReview] invalid_state',
+      expect.objectContaining({
+        errorName: 'ZodError',
+        issueCount: expect.any(Number),
+        user_id: TEST_USER.id,
+        card_id: TEST_CARD_ID,
+      }),
+    );
+    const serialized = JSON.stringify(consoleSpy.mock.calls);
+    expect(serialized).not.toContain('PII_SENTINEL_DO_NOT_LOG');
+  });
+
+  // ===== Concurrent update (council r1 bugs non-negotiable) ==========
+
+  it('concurrent_update: 40001 from RPC → distinct errorKind', async () => {
+    getUserMock.mockResolvedValue({ data: { user: TEST_USER } });
+    setSelectSuccess(emptyCardRow());
+    rpcMock.mockResolvedValue({
+      error: {
+        name: 'PostgresError',
+        code: '40001',
+        message: 'CARDCONTENT_SECRET_DO_NOT_LOG: serialization_failure',
+      },
+    });
+
+    const { submitReview } = await import('./actions');
+    const result = await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+    expect(result).toEqual({ ok: false, errorKind: 'concurrent_update' });
+    expect(counterMock).toHaveBeenCalledWith('review.rating.failed', {
+      reason: 'concurrent_update',
+      user_id: TEST_USER.id,
+    });
+    const serialized = JSON.stringify(consoleSpy.mock.calls);
+    expect(serialized).not.toContain('CARDCONTENT_SECRET_DO_NOT_LOG');
+  });
+
+  // ===== Idempotency replay (council r1 bugs non-negotiable) =========
+
+  it('idempotency: same idempotencyKey twice both return ok (RPC handles dedup)', async () => {
+    getUserMock.mockResolvedValue({ data: { user: TEST_USER } });
+    setSelectSuccess(emptyCardRow());
+    rpcMock.mockResolvedValue({ error: null });
+
+    const { submitReview } = await import('./actions');
+    const r1 = await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+    const r2 = await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    // Both calls passed the same idempotency_key to the RPC; the SQL
+    // function's on-conflict handles dedup. We assert the action's contract.
+    expect(rpcMock).toHaveBeenCalledTimes(2);
+    // noUncheckedIndexedAccess: tuple-positional reads need ! since we
+    // just asserted toHaveBeenCalledTimes(2). Justified.
+    expect(rpcMock.mock.calls[0]![1]).toMatchObject({
+      p_idempotency_key: VALID_KEY,
+    });
+    expect(rpcMock.mock.calls[1]![1]).toMatchObject({
+      p_idempotency_key: VALID_KEY,
+    });
+  });
+
+  // ===== Generic persist_failed ======================================
+
+  it('persist_failed: non-40001 RPC error → persist_failed errorKind', async () => {
+    getUserMock.mockResolvedValue({ data: { user: TEST_USER } });
+    setSelectSuccess(emptyCardRow());
+    rpcMock.mockResolvedValue({
+      error: { name: 'PostgresError', code: '23505', message: 'CARDCONTENT_SECRET_DO_NOT_LOG' },
+    });
+
+    const { submitReview } = await import('./actions');
+    const result = await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+    expect(result).toEqual({ ok: false, errorKind: 'persist_failed' });
+    const serialized = JSON.stringify(consoleSpy.mock.calls);
+    expect(serialized).not.toContain('CARDCONTENT_SECRET_DO_NOT_LOG');
+  });
+
+  // ===== Happy path =================================================
+
+  it('happy path: empty state initialises, RPC called with correct args, viewed counter fires', async () => {
+    getUserMock.mockResolvedValue({ data: { user: TEST_USER } });
+    setSelectSuccess(emptyCardRow());
+    rpcMock.mockResolvedValue({ error: null });
+
+    const { submitReview } = await import('./actions');
+    const result = await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+    expect(result.ok).toBe(true);
+
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+    const [fnName, args] = rpcMock.mock.calls[0] as [string, Record<string, unknown>];
+    expect(fnName).toBe('fn_review_card');
+    expect(args).toMatchObject({
+      p_card_id: TEST_CARD_ID,
+      p_rating: 3,
+      p_idempotency_key: VALID_KEY,
+    });
+    expect(counterMock).toHaveBeenCalledWith('review.rating.submitted', {
+      user_id: TEST_USER.id,
+      rating: '3',
+      is_new_card: 'true',
+    });
+  });
+
+  // ===== Top-level catch =============================================
+
+  it('unhandled error path: getUser throws → unhandled errorKind, PII-safe log', async () => {
+    getUserMock.mockRejectedValueOnce(
+      new Error('CARDCONTENT_SECRET_DO_NOT_LOG: surprise'),
+    );
+    const { submitReview } = await import('./actions');
+    const result = await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+    expect(result).toEqual({ ok: false, errorKind: 'unhandled' });
+    expect(consoleSpy).toHaveBeenCalledWith('[/review submitReview] unhandled', {
+      errorName: 'Error',
+    });
+    const serialized = JSON.stringify(consoleSpy.mock.calls);
+    expect(serialized).not.toContain('CARDCONTENT_SECRET_DO_NOT_LOG');
+  });
+
+  // ===== Counter labels never include card content ==================
+
+  it('counter labels never include card content', async () => {
+    getUserMock.mockResolvedValue({ data: { user: TEST_USER } });
+    const xss = '<script>alert(1)</script>';
+    setSelectSuccess({ id: TEST_CARD_ID, fsrs_state: {} });
+    rpcMock.mockResolvedValue({ error: null });
+
+    const { submitReview } = await import('./actions');
+    await submitReview(TEST_CARD_ID, 3, VALID_KEY);
+    void xss; // sentinel for the negative assertion below
+
+    const serialized = JSON.stringify(counterMock.mock.calls);
+    expect(serialized).not.toContain('script');
+    expect(serialized).not.toContain('alert(1)');
+  });
+});

--- a/apps/web/app/review/actions.ts
+++ b/apps/web/app/review/actions.ts
@@ -1,0 +1,213 @@
+'use server';
+
+// /review submitReview server action — closes the SRS loop opened by PR #42.
+// Council r1/r2 (PR #48) folded: idempotency key + optimistic concurrency +
+// Zod validation + per-user rate limit + PII-safe error logging.
+//
+// PII DISCIPLINE (CLAUDE.md non-negotiable + the rebuttal-protocol rule):
+//   srs_cards.{question, answer} are LLM output derived from user PDFs.
+//   This action NEVER touches those columns AND NEVER logs error.message
+//   (PostgREST messages can echo query/row text). Logged fields are
+//   strictly: errorName, code, user_id, card_id, plus issueCount for
+//   ZodError. Card content is NEVER a counter label.
+import { ZodError } from 'zod';
+import { counter } from '@llmwiki/lib-metrics';
+import {
+  isValidRating,
+  emptyFsrsState,
+  nextState,
+  parseFsrsState,
+  type FsrsCardState,
+  type RatingValue,
+} from '@llmwiki/lib-srs';
+import {
+  makeRatingLimiter,
+  RateLimitExceededError,
+  RatelimitUnavailableError,
+} from '@llmwiki/lib-ratelimit';
+import { supabaseForRequest } from '../../lib/supabase';
+
+export interface SubmitReviewResult {
+  ok: boolean;
+  errorKind?:
+    | 'invalid_rating'
+    | 'invalid_idempotency_key'
+    | 'card_not_found'
+    | 'persist_failed'
+    | 'invalid_state'
+    | 'concurrent_update'
+    | 'rate_limited'
+    | 'unauthenticated'
+    | 'unhandled';
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Lazy-initialize the limiter so module import does NOT read env at
+// load time. The route-module-load.test.ts CI guard requires every
+// page/route module to import cleanly with env scrubbed (the original
+// v0 deploy bug — see that test's header). Memoized after first call.
+let _ratingLimiter: ReturnType<typeof makeRatingLimiter> | null = null;
+function getRatingLimiter(): ReturnType<typeof makeRatingLimiter> {
+  if (!_ratingLimiter) _ratingLimiter = makeRatingLimiter();
+  return _ratingLimiter;
+}
+
+export async function submitReview(
+  cardId: string,
+  rating: number,
+  idempotencyKey: string,
+): Promise<SubmitReviewResult> {
+  // Council r2 bugs nice-to-have fold: top-level try/catch so any
+  // unhandled error (rate-limiter fail-open bug, ts-fsrs throw on edge
+  // input, etc.) returns a structured response with PII-safe log instead
+  // of bubbling to the framework as a 500.
+  try {
+    return await submitReviewImpl(cardId, rating, idempotencyKey);
+  } catch (err) {
+    const errorName = err instanceof Error ? err.name : typeof err;
+    console.error('[/review submitReview] unhandled', { errorName });
+    counter('review.rating.failed', { reason: 'unhandled' });
+    return { ok: false, errorKind: 'unhandled' };
+  }
+}
+
+async function submitReviewImpl(
+  cardId: string,
+  rating: number,
+  idempotencyKey: string,
+): Promise<SubmitReviewResult> {
+  // Validate inputs BEFORE any DB call. Defense in depth — SQL function
+  // also checks rating range, but cheap-and-loud rejection at the boundary
+  // keeps PostgresError noise out of logs and Tier E quota intact.
+  if (!isValidRating(rating)) {
+    counter('review.rating.rejected', { reason: 'invalid_rating' });
+    return { ok: false, errorKind: 'invalid_rating' };
+  }
+  if (!UUID_RE.test(cardId)) {
+    counter('review.rating.rejected', { reason: 'invalid_card_id' });
+    return { ok: false, errorKind: 'invalid_rating' };
+  }
+  if (!UUID_RE.test(idempotencyKey)) {
+    counter('review.rating.rejected', { reason: 'invalid_idempotency_key' });
+    return { ok: false, errorKind: 'invalid_idempotency_key' };
+  }
+
+  const rls = await supabaseForRequest();
+  const {
+    data: { user },
+  } = await rls.auth.getUser();
+  if (!user) {
+    return { ok: false, errorKind: 'unauthenticated' };
+  }
+
+  // Per-user rate limit (Tier E, 30/min). Fail-closed on quota exceeded;
+  // fail-open on limiter unavailable (matches Tier B/D pattern — better
+  // to let a real user through than block on Upstash outage).
+  try {
+    await getRatingLimiter().reserve(user.id);
+  } catch (err) {
+    if (err instanceof RateLimitExceededError) {
+      counter('review.rating.failed', {
+        reason: 'rate_limited',
+        user_id: user.id,
+      });
+      return { ok: false, errorKind: 'rate_limited' };
+    }
+    if (err instanceof RatelimitUnavailableError) {
+      // Fail-open: continue. The limiter's own monitoring path logs the
+      // alert (Tier B/D pattern shipped in PR #28).
+    } else {
+      throw err;
+    }
+  }
+
+  // Load the card's current state (RLS-scoped). If the user doesn't own
+  // it OR it doesn't exist, the select returns null/error → card_not_found.
+  // Council r1 security non-negotiable: this is the consistently-passing
+  // RLS-blocked test target — actions.test.ts asserts that User A cannot
+  // load User B's card via this path.
+  const { data: card, error: loadErr } = await rls
+    .from('srs_cards')
+    .select('id, fsrs_state')
+    .eq('id', cardId)
+    .single();
+  if (loadErr || !card) {
+    console.error('[/review submitReview] card_load_failed', {
+      errorName: loadErr?.name ?? 'NotFound',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- supabase error untyped
+      code: (loadErr as any)?.code ?? null,
+      user_id: user.id,
+      card_id: cardId,
+    });
+    counter('review.rating.failed', {
+      reason: 'card_not_found',
+      user_id: user.id,
+    });
+    return { ok: false, errorKind: 'card_not_found' };
+  }
+
+  // Council r1 bugs non-negotiable: parse fsrs_state through Zod before
+  // passing to nextState. Malformed JSONB returns invalid_state instead
+  // of crashing.
+  let currentState: FsrsCardState;
+  try {
+    currentState = parseFsrsState(card.fsrs_state) ?? emptyFsrsState();
+  } catch (err) {
+    if (err instanceof ZodError) {
+      console.error('[/review submitReview] invalid_state', {
+        errorName: 'ZodError',
+        // Count only — never issue.path or issue.message; path could
+        // include card content under deep validation.
+        issueCount: err.issues.length,
+        user_id: user.id,
+        card_id: cardId,
+      });
+      counter('review.rating.failed', {
+        reason: 'invalid_state',
+        user_id: user.id,
+      });
+      return { ok: false, errorKind: 'invalid_state' };
+    }
+    throw err;
+  }
+
+  // Compute next state. nextState is a pure function on validated input;
+  // a throw here would be a library bug. Surface to the top-level catch.
+  const { state: next, due } = nextState(currentState, rating as RatingValue);
+
+  // Persist atomically via the SQL function (idempotent + optimistic-concurrent).
+  const { error: rpcErr } = await rls.rpc('fn_review_card', {
+    p_card_id: cardId,
+    p_rating: rating,
+    p_next_state: next,
+    p_due_at: due.toISOString(),
+    p_prev_state: currentState,
+    p_idempotency_key: idempotencyKey,
+  });
+  if (rpcErr) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- supabase error untyped
+    const code = (rpcErr as any)?.code ?? null;
+    // 40001 (serialization_failure) = optimistic-concurrency collision.
+    // Distinct error kind so the client can re-fetch + retry against the
+    // new state.
+    const errorKind: SubmitReviewResult['errorKind'] =
+      code === '40001' ? 'concurrent_update' : 'persist_failed';
+    console.error('[/review submitReview] persist_failed', {
+      errorName: rpcErr.name ?? 'UnknownError',
+      code,
+      user_id: user.id,
+      card_id: cardId,
+    });
+    counter('review.rating.failed', { reason: errorKind, user_id: user.id });
+    return { ok: false, errorKind };
+  }
+
+  counter('review.rating.submitted', {
+    user_id: user.id,
+    rating: String(rating),
+    is_new_card: currentState.state === 0 ? 'true' : 'false',
+  });
+  return { ok: true };
+}

--- a/apps/web/components/ReviewDeck.test.tsx
+++ b/apps/web/components/ReviewDeck.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { ReviewDeck, nextIndex } from '../app/review/ReviewDeck';
+import {
+  ReviewDeck,
+  nextIndex,
+  generateIdempotencyKey,
+} from '../app/review/ReviewDeck';
 
 // Vitest env is `node` (apps/web/vitest.config.ts) — no jsdom. Static
 // render coverage uses `react-dom/server`. Dynamic interaction (reveal
@@ -163,5 +167,81 @@ describe('nextIndex helper (council r2 double-click safety)', () => {
     nextIndex(1, 5);
     expect(consoleSpy).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
+  });
+});
+
+// ===== PR #48 — FSRS rating ===========================================
+//
+// renderToStaticMarkup gives us the initial-render markup (revealed=false).
+// The rating cluster only renders after answer reveal, which requires
+// state mutation that vitest-node can't drive. Interaction tests for the
+// reveal→rate→advance flow live in:
+//   - actions.test.ts (server-action contract; load-bearing per the
+//     rebuttal-protocol failure-mode rule)
+//   - tests/a11y/smoke.spec.ts (rating cluster static markup verification)
+//   - future: a Playwright spec once the dev-server CI gate exists
+// What we CAN test here without jsdom is the pure helper +
+// initial-render shape:
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe('generateIdempotencyKey', () => {
+  it('returns a UUIDv4-shaped string when crypto.randomUUID is available', () => {
+    const key = generateIdempotencyKey();
+    expect(key).toMatch(UUID_RE);
+  });
+
+  it('successive calls produce distinct keys (no accidental reuse)', () => {
+    const a = generateIdempotencyKey();
+    const b = generateIdempotencyKey();
+    const c = generateIdempotencyKey();
+    expect(a).not.toBe(b);
+    expect(b).not.toBe(c);
+    expect(a).not.toBe(c);
+  });
+
+  it('returns empty string when crypto.randomUUID is unavailable (council r2 fold)', () => {
+    // globalThis.crypto is a getter on Node 25 — direct assignment
+    // throws. vi.stubGlobal handles the restore + assignment.
+    const originalCrypto = globalThis.crypto;
+    vi.stubGlobal('crypto', { ...originalCrypto, randomUUID: undefined });
+    try {
+      expect(generateIdempotencyKey()).toBe('');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe('ReviewDeck rating cluster (initial-render markup)', () => {
+  it('does NOT render rating buttons when answer is hidden (default state)', () => {
+    const html = renderToStaticMarkup(
+      <ReviewDeck
+        cards={[{ id: '1', question: 'q', answer: 'a' }]}
+        emptyCopy="empty"
+      />,
+    );
+    // Rating button labels must not appear in the unrevealed state.
+    expect(html).not.toContain('Again');
+    expect(html).not.toContain('Hard');
+    expect(html).not.toContain('Good');
+    expect(html).not.toContain('Easy');
+    // Rating cluster's role/label also absent.
+    expect(html).not.toContain('Rate this card');
+  });
+
+  it('keeps the Show answer + Next card buttons visible in the unrevealed state', () => {
+    const html = renderToStaticMarkup(
+      <ReviewDeck
+        cards={[
+          { id: '1', question: 'q1', answer: 'a1' },
+          { id: '2', question: 'q2', answer: 'a2' },
+        ]}
+        emptyCopy="empty"
+      />,
+    );
+    expect(html).toContain('Show answer');
+    expect(html).toContain('Next card');
   });
 });

--- a/apps/web/lib/i18n.ts
+++ b/apps/web/lib/i18n.ts
@@ -28,7 +28,14 @@ type Key =
   | 'review.hide_answer'
   | 'review.next_card'
   | 'review.load_error'
-  | 'review.render_error';
+  | 'review.render_error'
+  | 'review.rating.again'
+  | 'review.rating.hard'
+  | 'review.rating.good'
+  | 'review.rating.easy'
+  | 'review.rating_error'
+  | 'review.rating_rate_limit_error'
+  | 'review.rating_pending';
 
 const STRINGS: Record<Key, string> = {
   'app.name': 'LLM Wiki · Study Group',
@@ -59,6 +66,14 @@ const STRINGS: Record<Key, string> = {
   'review.load_error': "Couldn't load your flashcards. Please refresh in a moment.",
   'review.render_error':
     "Something went wrong rendering this card. Refresh to try again.",
+  'review.rating.again': 'Again',
+  'review.rating.hard': 'Hard',
+  'review.rating.good': 'Good',
+  'review.rating.easy': 'Easy',
+  'review.rating_error': "Couldn't save your rating. Please try again.",
+  'review.rating_rate_limit_error':
+    "You're rating too quickly. Please wait a moment.",
+  'review.rating_pending': 'Saving…',
 };
 
 export function t(key: Key): string {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@llmwiki/lib-ai": "workspace:*",
     "@llmwiki/lib-metrics": "workspace:*",
     "@llmwiki/lib-ratelimit": "workspace:*",
+    "@llmwiki/lib-srs": "workspace:*",
     "@supabase/ssr": "0.4.1",
     "@supabase/supabase-js": "^2.45.0",
     "inngest": "^3.22.0",

--- a/apps/web/tests/a11y/smoke.spec.ts
+++ b/apps/web/tests/a11y/smoke.spec.ts
@@ -34,6 +34,45 @@ test.describe('a11y smoke', () => {
     expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
   });
 
+  test('/review rating cluster — PR #48 chrome (color-contrast on rating buttons)', async ({ page }) => {
+    // Council r1 a11y fold (PR #48): verify bg-warning + text-brand-900
+    // (the Hard button) passes WCAG AA 3:1 for UI components. axe-core's
+    // color-contrast rule fails the test if the chosen amber is too
+    // light against the dark text. Re-uses the static-HTML pattern + the
+    // same 4 brand tokens (danger / warning / success / brand-900) the
+    // ReviewDeck buttons use.
+    await page.setContent(`
+      <!doctype html>
+      <html lang="en"><head><title>review-rating</title></head>
+      <body style="background:#fff;color:#0f172a;font-family:sans-serif;padding:1rem">
+        <main>
+          <h1 style="font-size:1.5rem;color:#0f172a">Review</h1>
+          <section aria-labelledby="card-heading" style="max-width:36rem">
+            <h2 id="card-heading" tabindex="-1"
+                style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">
+              Card 1 of 1
+            </h2>
+            <div style="border:1px solid #cbd5e1;border-radius:0.375rem;padding:1.5rem;background:#fff">
+              <p style="color:#0f172a;font-size:1.125rem;margin:0">Sample question text</p>
+              <div aria-live="polite" aria-atomic="true">
+                <p style="color:#0f172a;margin-top:1rem;padding-top:1rem;border-top:1px solid #e2e8f0">Sample answer text</p>
+              </div>
+            </div>
+            <div role="group" aria-label="Rate this card" style="margin-top:1rem;display:flex;gap:0.5rem;flex-wrap:wrap">
+              <button type="button" style="background:#b91c1c;color:#fff;padding:0.5rem 1rem;border-radius:0.375rem;min-height:44px;border:none">Again</button>
+              <button type="button" style="background:#f59e0b;color:#0f172a;padding:0.5rem 1rem;border-radius:0.375rem;min-height:44px;border:none">Hard</button>
+              <button type="button" style="background:#15803d;color:#fff;padding:0.5rem 1rem;border-radius:0.375rem;min-height:44px;border:none">Good</button>
+              <button type="button" style="background:#0f172a;color:#fff;padding:0.5rem 1rem;border-radius:0.375rem;min-height:44px;border:none">Easy</button>
+            </div>
+          </section>
+        </main>
+      </body></html>`);
+    const results = await new AxeBuilder({ page })
+      .withRules(['color-contrast', 'target-size'])
+      .analyze();
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+  });
+
   test('/review surface placeholder — issue #38 chrome', async ({ page }) => {
     // Mirrors what /review renders: page heading, sr-only card heading
     // (programmatically focusable), one card surface with question +

--- a/packages/lib/ratelimit/src/index.test.ts
+++ b/packages/lib/ratelimit/src/index.test.ts
@@ -4,10 +4,12 @@ import {
   makeIngestEventLimiter,
   makeMagicLinkLimiter,
   makeAuthCallbackLimiter,
+  makeRatingLimiter,
   RateLimitExceededError,
   RatelimitUnavailableError,
   TOKEN_BUDGET_PER_HOUR,
   AUTH_CALLBACK_PER_IP_PER_MINUTE,
+  RATING_SUBMITS_PER_MINUTE,
 } from './index';
 
 interface PipelineLike {
@@ -262,5 +264,34 @@ describe('auth callback limiter (tier D)', () => {
     const err = new RateLimitExceededError('auth_callback_ip', new Date());
     expect(err.kind).toBe('auth_callback_ip');
     expect(err).toBeInstanceOf(RateLimitExceededError);
+  });
+});
+
+describe('rating limiter (tier E)', () => {
+  it('exports a 30/min constant', () => {
+    expect(RATING_SUBMITS_PER_MINUTE).toBe(30);
+  });
+
+  it('throws RatelimitUnavailable on upstash failure (caller decides fail-open)', async () => {
+    const redis = { eval: async () => { throw new Error('down'); } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    const lim = makeRatingLimiter({ redis: redis as any });
+    await expect(lim.reserve('user-a')).rejects.toBeInstanceOf(
+      RatelimitUnavailableError,
+    );
+  });
+
+  it('makeRatingLimiter returns a limiter with reserve() method', () => {
+    // Smoke test: per-user isolation is a property of @upstash/ratelimit's
+    // SlidingWindow + our `user:${userId}` keying + `rl:rating` prefix.
+    // The keying is identical in shape to Tier A (ingest events) which
+    // is exercised in production. Fully simulating the Upstash protocol
+    // (Lua script, multi-key reads) here would re-test the upstream lib.
+    // Instead: confirm the factory produces a limiter object with the
+    // expected shape; rely on Tier A's parallel test for the eval path.
+    const redis = { eval: async () => [1, Date.now() + 60_000, 30, 29] };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    const lim = makeRatingLimiter({ redis: redis as any });
+    expect(typeof lim.reserve).toBe('function');
   });
 });

--- a/packages/lib/ratelimit/src/index.ts
+++ b/packages/lib/ratelimit/src/index.ts
@@ -22,7 +22,8 @@ export class RateLimitExceededError extends Error {
       | 'token_budget'
       | 'magic_link_ip'
       | 'magic_link_email'
-      | 'auth_callback_ip',
+      | 'auth_callback_ip'
+      | 'rating_submits',
     public readonly resetsAt: Date,
   ) {
     super(`rate limit exceeded: ${kind}; resets at ${resetsAt.toISOString()}`);
@@ -280,6 +281,49 @@ export function makeMagicLinkLimiter(deps: RateLimitDeps = {}) {
     }
     if (!emailRes.success) {
       throw new RateLimitExceededError('magic_link_email', new Date(emailRes.reset));
+    }
+  }
+
+  return { reserve };
+}
+
+// ----- Tier E: review rating limiter (per-user, minute window) -------------
+//
+// /review's submitReview server action is an authenticated mutation
+// endpoint. CLAUDE.md non-negotiables require rate-limiting on every
+// external/mutation call. 30 ratings / user / minute is well above
+// realistic study behavior (a serious session is ~5–10 cards/min) and
+// well below abuse rates. Council r1 security non-negotiable on PR #48.
+
+export const RATING_SUBMITS_PER_MINUTE = 30;
+
+export function makeRatingLimiter(deps: RateLimitDeps = {}) {
+  const redis = makeRedis(deps);
+  const limiter = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(RATING_SUBMITS_PER_MINUTE, '1 m'),
+    analytics: false,
+    prefix: 'rl:rating',
+  });
+
+  /**
+   * Check-and-decrement the per-user rating counter. Throws:
+   *   - RateLimitExceededError if the user is over the limit (server
+   *     action returns errorKind: 'rate_limited').
+   *   - RatelimitUnavailableError if Upstash is unreachable. Caller
+   *     decides fail-open vs fail-closed; submitReview chooses fail-open
+   *     (matches Tier B/D pattern — better to let a real user through
+   *     than block on limiter outage).
+   */
+  async function reserve(userId: string): Promise<void> {
+    let result: Awaited<ReturnType<typeof limiter.limit>>;
+    try {
+      result = await limiter.limit(`user:${userId}`);
+    } catch {
+      throw new RatelimitUnavailableError();
+    }
+    if (!result.success) {
+      throw new RateLimitExceededError('rating_submits', new Date(result.reset));
     }
   }
 

--- a/packages/lib/srs/package.json
+++ b/packages/lib/srs/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@llmwiki/lib-srs",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "ts-fsrs": "5.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/lib/srs/src/index.test.ts
+++ b/packages/lib/srs/src/index.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+import { ZodError } from 'zod';
+import {
+  RATING_AGAIN,
+  RATING_HARD,
+  RATING_GOOD,
+  RATING_EASY,
+  emptyFsrsState,
+  isValidRating,
+  nextState,
+  parseFsrsState,
+  type FsrsCardState,
+  type RatingValue,
+} from './index';
+
+// Reference timestamp so tests are deterministic w.r.t. the `now` arg.
+// The fuzz still varies the exact `due` field; tests assert ordering +
+// invariants, not exact values, where fuzz applies.
+const NOW = new Date('2026-04-24T00:00:00.000Z');
+
+describe('isValidRating', () => {
+  it('accepts 1 / 2 / 3 / 4', () => {
+    expect(isValidRating(1)).toBe(true);
+    expect(isValidRating(2)).toBe(true);
+    expect(isValidRating(3)).toBe(true);
+    expect(isValidRating(4)).toBe(true);
+  });
+
+  it('rejects out-of-range integers', () => {
+    expect(isValidRating(0)).toBe(false);
+    expect(isValidRating(5)).toBe(false);
+    expect(isValidRating(-1)).toBe(false);
+    expect(isValidRating(99)).toBe(false);
+  });
+
+  it('rejects non-integers + wrong types', () => {
+    expect(isValidRating(1.5)).toBe(false);
+    expect(isValidRating('3')).toBe(false);
+    expect(isValidRating(null)).toBe(false);
+    expect(isValidRating(undefined)).toBe(false);
+    expect(isValidRating({})).toBe(false);
+    expect(isValidRating([])).toBe(false);
+  });
+});
+
+describe('emptyFsrsState', () => {
+  it('produces a never-reviewed state shape', () => {
+    const empty = emptyFsrsState(NOW);
+    expect(empty.state).toBe(0);
+    expect(empty.reps).toBe(0);
+    expect(empty.lapses).toBe(0);
+    expect(empty.stability).toBe(0);
+    expect(empty.difficulty).toBe(0);
+    expect(empty.elapsed_days).toBe(0);
+    expect(empty.scheduled_days).toBe(0);
+    expect(empty.due).toBe(NOW.toISOString());
+    expect(empty.last_review).toBeUndefined();
+  });
+});
+
+describe('parseFsrsState', () => {
+  it('returns null for null / undefined / {}', () => {
+    expect(parseFsrsState(null)).toBeNull();
+    expect(parseFsrsState(undefined)).toBeNull();
+    expect(parseFsrsState({})).toBeNull();
+  });
+
+  it('parses a valid state object', () => {
+    const valid = emptyFsrsState(NOW);
+    const parsed = parseFsrsState({ ...valid });
+    expect(parsed).not.toBeNull();
+    expect(parsed?.state).toBe(0);
+  });
+
+  it('throws ZodError on missing required fields', () => {
+    expect(() => parseFsrsState({ due: NOW.toISOString() })).toThrow(ZodError);
+  });
+
+  it('throws ZodError on wrong field types', () => {
+    expect(() =>
+      parseFsrsState({
+        due: 12345,
+        stability: 0,
+        difficulty: 0,
+        elapsed_days: 0,
+        scheduled_days: 0,
+        learning_steps: 0,
+        reps: 0,
+        lapses: 0,
+        state: 0,
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it('throws ZodError on invalid state enum', () => {
+    const invalid = { ...emptyFsrsState(NOW), state: 99 };
+    expect(() => parseFsrsState(invalid)).toThrow(ZodError);
+  });
+
+  it('throws ZodError on non-object inputs (not just {})', () => {
+    expect(() => parseFsrsState('a string')).toThrow(ZodError);
+    expect(() => parseFsrsState(42)).toThrow(ZodError);
+    expect(() => parseFsrsState(true)).toThrow(ZodError);
+  });
+
+  it('treats arrays as malformed (Zod expects object)', () => {
+    expect(() => parseFsrsState([1, 2, 3])).toThrow(ZodError);
+  });
+});
+
+describe('nextState', () => {
+  it('advances reps on a good rating from empty state', () => {
+    const empty = emptyFsrsState(NOW);
+    const result = nextState(empty, RATING_GOOD, NOW);
+    expect(result.state.reps).toBeGreaterThan(empty.reps);
+    expect(result.due.getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  it('keeps short interval on Again from empty state', () => {
+    const empty = emptyFsrsState(NOW);
+    const result = nextState(empty, RATING_AGAIN, NOW);
+    // Again on a never-reviewed card schedules within minutes / under a day.
+    const intervalMs = result.due.getTime() - NOW.getTime();
+    const oneDayMs = 24 * 60 * 60 * 1000;
+    expect(intervalMs).toBeLessThan(oneDayMs);
+  });
+
+  it('increments lapses on Again from a card already in review state', () => {
+    // FSRS only counts a "lapse" when transitioning OUT of review
+    // (state: 2) INTO relearning. From learning (state: 0/1) the
+    // algorithm resets to step 1 without bumping lapses. So construct
+    // a state: 2 card directly to test the lapse increment.
+    const reviewed: FsrsCardState = {
+      due: NOW.toISOString(),
+      stability: 50,
+      difficulty: 3,
+      elapsed_days: 30,
+      scheduled_days: 30,
+      learning_steps: 0,
+      reps: 10,
+      lapses: 0,
+      state: 2,
+      last_review: new Date(NOW.getTime() - 30 * 86400000).toISOString(),
+    };
+
+    const after = nextState(reviewed, RATING_AGAIN, NOW).state;
+    expect(after.lapses).toBeGreaterThan(reviewed.lapses);
+    // The card transitions to relearning (state: 3) on a lapse.
+    expect(after.state).toBe(3);
+  });
+
+  // FAILURE-MODE PROOF (council r1 rebuttal-protocol non-negotiable):
+  // The ordering invariant is the algorithm's load-bearing contract. If
+  // FSRS-5 math regresses, ordering breaks. Property-style: 5 random
+  // states; for each, all 4 ratings respect Easy > Good > Hard > Again.
+  it('ordering invariant: due(Easy) > due(Good) > due(Hard) > due(Again)', () => {
+    const seedStates: FsrsCardState[] = [
+      emptyFsrsState(NOW),
+      // A card in mid-learning.
+      {
+        due: NOW.toISOString(),
+        stability: 5,
+        difficulty: 5,
+        elapsed_days: 1,
+        scheduled_days: 1,
+        learning_steps: 0,
+        reps: 3,
+        lapses: 0,
+        state: 2,
+        last_review: new Date(NOW.getTime() - 86400000).toISOString(),
+      },
+      // A well-learned card.
+      {
+        due: NOW.toISOString(),
+        stability: 50,
+        difficulty: 3,
+        elapsed_days: 30,
+        scheduled_days: 30,
+        learning_steps: 0,
+        reps: 10,
+        lapses: 0,
+        state: 2,
+        last_review: new Date(NOW.getTime() - 30 * 86400000).toISOString(),
+      },
+      // A struggling card with high difficulty.
+      {
+        due: NOW.toISOString(),
+        stability: 1,
+        difficulty: 9,
+        elapsed_days: 1,
+        scheduled_days: 1,
+        learning_steps: 1,
+        reps: 5,
+        lapses: 3,
+        state: 3,
+        last_review: new Date(NOW.getTime() - 86400000).toISOString(),
+      },
+      // An easy card.
+      {
+        due: NOW.toISOString(),
+        stability: 100,
+        difficulty: 1,
+        elapsed_days: 60,
+        scheduled_days: 60,
+        learning_steps: 0,
+        reps: 20,
+        lapses: 0,
+        state: 2,
+        last_review: new Date(NOW.getTime() - 60 * 86400000).toISOString(),
+      },
+    ];
+
+    for (const state of seedStates) {
+      const ratings: RatingValue[] = [
+        RATING_AGAIN,
+        RATING_HARD,
+        RATING_GOOD,
+        RATING_EASY,
+      ];
+      const dues = ratings.map((r) => nextState(state, r, NOW).due.getTime());
+      const [again, hard, good, easy] = dues as [number, number, number, number];
+
+      // Strict ordering (Easy > Good > Hard > Again) only holds for
+      // cards in `state: 2` (review). For learning (state: 0) and
+      // relearning (state: 3), the algorithm uses fixed learning_steps
+      // ([1m, 10m] by default) for Again/Hard/Good — these can collapse
+      // to identical values within the steps. That's algorithmically
+      // correct, not a regression.
+      //
+      // The cross-state invariant the test load-bears: Easy >= Again
+      // for ALL states (Easy never schedules sooner than Again).
+      expect(easy).toBeGreaterThanOrEqual(again);
+
+      if (state.state === 2) {
+        expect(easy).toBeGreaterThan(good);
+        expect(good).toBeGreaterThan(hard);
+        expect(hard).toBeGreaterThan(again);
+      }
+    }
+  });
+
+  it('returns a serializable state shape (no Date instances in the state object)', () => {
+    const empty = emptyFsrsState(NOW);
+    const result = nextState(empty, RATING_GOOD, NOW);
+    // The returned state.due must be an ISO string so it round-trips
+    // through Postgres jsonb without TypeError.
+    expect(typeof result.state.due).toBe('string');
+    expect(() => new Date(result.state.due).toISOString()).not.toThrow();
+  });
+});

--- a/packages/lib/srs/src/index.ts
+++ b/packages/lib/srs/src/index.ts
@@ -1,0 +1,157 @@
+// FSRS scheduling wrapper. Localizes the ts-fsrs import to one file so
+// the rest of the codebase depends on the typed contract below, not the
+// underlying lib's API surface. A future swap (different lib, in-house
+// impl) only touches this file.
+//
+// VERSION-PINNED: Bumps require security council review. The ts-fsrs
+// algorithm version (FSRS-4 → FSRS-5) changed scheduling math; bumps
+// could change every user's review schedule. See packages/lib/srs/
+// package.json + the council r1 security non-negotiable on PR #48.
+import { z } from 'zod';
+import { FSRS, generatorParameters, type Card, type Grade } from 'ts-fsrs';
+
+export const RATING_AGAIN = 1;
+export const RATING_HARD = 2;
+export const RATING_GOOD = 3;
+export const RATING_EASY = 4;
+export type RatingValue = 1 | 2 | 3 | 4;
+
+export function isValidRating(r: unknown): r is RatingValue {
+  return r === 1 || r === 2 || r === 3 || r === 4;
+}
+
+/**
+ * Our wire shape for srs_cards.fsrs_state and review_history.{prev,next}_state.
+ * Matches ts-fsrs's Card serialization 1:1; explicit interface so a future
+ * lib swap can target a stable contract.
+ *
+ * Council r1 bugs fold (PR #48): the Zod schema below is the runtime
+ * validator. Any read of fsrs_state from the DB MUST go through
+ * `parseFsrsState` before passing to `nextState` — protects against
+ * malformed JSONB from a past bug, manual edit, or schema drift.
+ */
+export interface FsrsCardState {
+  due: string;
+  stability: number;
+  difficulty: number;
+  elapsed_days: number;
+  scheduled_days: number;
+  // ts-fsrs v5 added `learning_steps` to track the index within the
+  // (re)learning step sequence ([1m, 10m] by default). Persisted so
+  // resuming a card mid-learning works correctly.
+  learning_steps: number;
+  reps: number;
+  lapses: number;
+  state: 0 | 1 | 2 | 3;
+  last_review?: string;
+}
+
+export const FsrsCardStateSchema = z.object({
+  due: z.string().datetime({ offset: true }),
+  stability: z.number().finite().nonnegative(),
+  difficulty: z.number().finite(),
+  elapsed_days: z.number().finite().nonnegative(),
+  scheduled_days: z.number().finite().nonnegative(),
+  learning_steps: z.number().int().nonnegative(),
+  reps: z.number().int().nonnegative(),
+  lapses: z.number().int().nonnegative(),
+  state: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]),
+  last_review: z.string().datetime({ offset: true }).optional(),
+});
+
+/**
+ * Parse a value (typically `srs_cards.fsrs_state` from a Supabase select)
+ * into a typed `FsrsCardState`.
+ *
+ * Returns `null` for the empty-state sentinels (`null`, `undefined`, `{}`)
+ * so the caller can branch to `emptyFsrsState()` for never-reviewed cards.
+ *
+ * Throws `ZodError` on a non-empty malformed shape so the caller can decide
+ * whether to fail loud (server action returns invalid_state) or fall back
+ * to a fresh empty state. The decision is intentionally NOT made here —
+ * this is the validator, not the policy.
+ *
+ * Council r2 bugs nice-to-have fold (PR #48): also handles `null` and
+ * non-object inputs robustly (throws ZodError instead of crashing on
+ * Object.keys(null)).
+ */
+export function parseFsrsState(raw: unknown): FsrsCardState | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'object') {
+    // Force a ZodError so the caller's catch path treats this like any
+    // other malformed-state branch. Re-using the schema's parse() is the
+    // shortest path to that contract.
+    return FsrsCardStateSchema.parse(raw);
+  }
+  if (Object.keys(raw as object).length === 0) return null;
+  return FsrsCardStateSchema.parse(raw);
+}
+
+/**
+ * Initial state for a never-reviewed card. Matches ts-fsrs's empty-card
+ * shape but spelled out so the contract is readable + testable without
+ * importing the lib.
+ */
+export function emptyFsrsState(now: Date = new Date()): FsrsCardState {
+  return {
+    due: now.toISOString(),
+    stability: 0,
+    difficulty: 0,
+    elapsed_days: 0,
+    scheduled_days: 0,
+    learning_steps: 0,
+    reps: 0,
+    lapses: 0,
+    state: 0,
+  };
+}
+
+const fsrs = new FSRS(generatorParameters({ enable_fuzz: true }));
+
+/**
+ * Pure function: given the current state + a rating + "now", compute the
+ * next state and the next due date.
+ *
+ * "Pure" with one caveat: ts-fsrs's `enable_fuzz=true` adds randomness to
+ * the scheduled interval (anti-clustering on cards reviewed in batches).
+ * Tests that assert exact intervals must seed Math.random or disable fuzz;
+ * tests that assert ordering ("Easy interval > Good interval > Hard
+ * interval > Again interval") are fuzz-stable.
+ */
+export function nextState(
+  current: FsrsCardState,
+  rating: RatingValue,
+  now: Date = new Date(),
+): { state: FsrsCardState; due: Date } {
+  const card: Card = {
+    due: new Date(current.due),
+    stability: current.stability,
+    difficulty: current.difficulty,
+    elapsed_days: current.elapsed_days,
+    scheduled_days: current.scheduled_days,
+    learning_steps: current.learning_steps,
+    reps: current.reps,
+    lapses: current.lapses,
+    state: current.state as Card['state'],
+    last_review: current.last_review ? new Date(current.last_review) : undefined,
+  };
+
+  const result = fsrs.next(card, now, rating as Grade);
+  const next = result.card;
+
+  return {
+    state: {
+      due: next.due.toISOString(),
+      stability: next.stability,
+      difficulty: next.difficulty,
+      elapsed_days: next.elapsed_days,
+      scheduled_days: next.scheduled_days,
+      learning_steps: next.learning_steps,
+      reps: next.reps,
+      lapses: next.lapses,
+      state: next.state as FsrsCardState['state'],
+      last_review: next.last_review?.toISOString(),
+    },
+    due: next.due,
+  };
+}

--- a/packages/lib/srs/tsconfig.json
+++ b/packages/lib/srs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src", "noEmit": true },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/lib/srs/vitest.config.ts
+++ b/packages/lib/srs/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({ test: { environment: 'node', include: ['src/**/*.test.ts'] } });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@llmwiki/lib-ratelimit':
         specifier: workspace:*
         version: link:../../packages/lib/ratelimit
+      '@llmwiki/lib-srs':
+        specifier: workspace:*
+        version: link:../../packages/lib/srs
       '@llmwiki/prompts':
         specifier: workspace:*
         version: link:../../packages/prompts
@@ -213,6 +216,22 @@ importers:
       '@upstash/redis':
         specifier: ^1.34.0
         version: 1.37.0
+    devDependencies:
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)
+
+  packages/lib/srs:
+    dependencies:
+      ts-fsrs:
+        specifier: 5.0.0
+        version: 5.0.0
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
     devDependencies:
       typescript:
         specifier: ^5.5.0
@@ -3602,6 +3621,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-fsrs@5.0.0:
+    resolution: {integrity: sha512-I2jsVdyM0m6EU4w64nRj7NWueiVPiFmexEF2xBVQ03yA4WQBWi+siJZj0eu6EhoxuS5MCw75ZJnfU8q2wm1LDQ==}
+    engines: {node: '>=18.0.0'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -7726,6 +7749,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-fsrs@5.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 

--- a/supabase/migrations/20260424000001_review_history_idempotency.sql
+++ b/supabase/migrations/20260424000001_review_history_idempotency.sql
@@ -1,0 +1,25 @@
+-- Council r1 bugs non-negotiable on PR #48: idempotency key for retry-safe
+-- reviews. A client retry after a network drop must NOT double-apply the
+-- rating (which would advance fsrs_state twice + create a duplicate
+-- review_history row).
+--
+-- Backfill: existing rows (none in v0 — table is empty pre-PR-#48) get a
+-- generated UUID via uuid_generate_v4() so the not-null constraint holds
+-- even on re-runs against a populated test DB. The unique
+-- (user_id, idempotency_key) index is the dedup key.
+
+alter table public.review_history
+  add column idempotency_key text;
+
+update public.review_history
+  set idempotency_key = uuid_generate_v4()::text
+  where idempotency_key is null;
+
+alter table public.review_history
+  alter column idempotency_key set not null;
+
+create unique index review_history_idempotency_unique
+  on public.review_history (user_id, idempotency_key);
+
+comment on column public.review_history.idempotency_key is
+  'Client-generated UUIDv4 per rating click. Retries with the same key are no-ops via the (user_id, idempotency_key) unique index. Council r1 bugs non-negotiable on PR #48.';

--- a/supabase/migrations/20260424000002_fn_review_card.sql
+++ b/supabase/migrations/20260424000002_fn_review_card.sql
@@ -1,0 +1,96 @@
+-- Atomic review: idempotent insert of review_history + optimistic-concurrency
+-- update of srs_cards. RLS-scoped via security invoker.
+--
+-- Council r1 bugs + security non-negotiables (PR #48):
+--   - Idempotency: insert review_history FIRST with on conflict (user_id,
+--     idempotency_key) do nothing. Replays short-circuit to a no-op success
+--     without touching srs_cards.
+--   - Optimistic concurrency: update srs_cards with WHERE
+--     fsrs_state = p_prev_state. Raises 40001 on collision so the server
+--     action returns errorKind: 'concurrent_update'.
+--   - security invoker: caller's auth.uid() flows through to RLS checks
+--     on srs_cards_own + review_history_own (per-user isolation).
+
+create or replace function public.fn_review_card(
+  p_card_id uuid,
+  p_rating smallint,
+  p_next_state jsonb,
+  p_due_at timestamptz,
+  p_prev_state jsonb,
+  p_idempotency_key text
+) returns void
+language plpgsql
+security invoker
+as $$
+declare
+  v_user_id uuid;
+  v_inserted_id uuid;
+  v_updated_count int;
+begin
+  -- Validate rating range (defense in depth — server action also checks).
+  if p_rating not in (1, 2, 3, 4) then
+    raise exception 'invalid rating: %', p_rating using errcode = '22023';
+  end if;
+
+  -- Read user_id from the card row, scoped by RLS. If the row is invisible
+  -- (RLS blocks: not the user's card) OR doesn't exist, this returns null.
+  -- Fail loud with insufficient_privilege so the server action returns
+  -- card_not_found rather than producing partial state.
+  select user_id into v_user_id
+    from public.srs_cards
+    where id = p_card_id;
+  if v_user_id is null then
+    raise exception 'card not found or not accessible: %', p_card_id
+      using errcode = '42501';
+  end if;
+
+  -- Idempotency check: insert review_history FIRST. If the
+  -- (user_id, idempotency_key) pair already exists, this is a retry —
+  -- ON CONFLICT DO NOTHING returns no row, and we short-circuit to a
+  -- successful no-op (the original write already advanced the card state).
+  insert into public.review_history (
+    card_id, user_id, rating, prev_state, next_state, idempotency_key
+  )
+  values (
+    p_card_id, v_user_id, p_rating, p_prev_state, p_next_state, p_idempotency_key
+  )
+  on conflict (user_id, idempotency_key) do nothing
+  returning id into v_inserted_id;
+
+  if v_inserted_id is null then
+    -- Replay: the original review already happened. No state mutation
+    -- needed; return success so the client's retry treats this as success.
+    return;
+  end if;
+
+  -- Optimistic concurrency: update card state ONLY if fsrs_state matches
+  -- what the client computed `next_state` from. If a concurrent
+  -- submitReview already advanced the state, this UPDATE matches 0 rows
+  -- and we raise serialization_failure so the server action can return
+  -- concurrent_update.
+  update public.srs_cards
+    set fsrs_state = p_next_state,
+        due_at = p_due_at
+    where id = p_card_id
+      and fsrs_state = p_prev_state;
+
+  get diagnostics v_updated_count = row_count;
+  if v_updated_count = 0 then
+    raise exception 'concurrent update on card %', p_card_id
+      using errcode = '40001';
+  end if;
+end;
+$$;
+
+comment on function public.fn_review_card(
+  uuid, smallint, jsonb, timestamptz, jsonb, text
+) is
+  'Atomic review: idempotent insert of review_history + optimistic-concurrency update of srs_cards. RLS-scoped via security invoker. Council r1 (PR #48) folded idempotency + optimistic concurrency.';
+
+revoke all on function public.fn_review_card(
+  uuid, smallint, jsonb, timestamptz, jsonb, text
+) from public;
+
+grant execute on function public.fn_review_card(
+  uuid, smallint, jsonb, timestamptz, jsonb, text
+) to authenticated;

--- a/supabase/migrations/20260424000003_fn_review_card_down.sql
+++ b/supabase/migrations/20260424000003_fn_review_card_down.sql
@@ -1,0 +1,18 @@
+-- Down-migration for PR #48 schema changes. Council r1 arch fold.
+-- Run in reverse order of the up migrations:
+--   1. Drop the function (20260424000002).
+--   2. Drop the unique index + column (20260424000001).
+--
+-- IMPORTANT: this file is NOT auto-applied by supabase migrate up. It is
+-- preserved as an operator-runnable script for emergency rollback. Apply
+-- via `supabase db reset` against a staging snapshot or psql against the
+-- project's connection string.
+
+drop function if exists public.fn_review_card(
+  uuid, smallint, jsonb, timestamptz, jsonb, text
+);
+
+drop index if exists public.review_history_idempotency_unique;
+
+alter table public.review_history
+  drop column if exists idempotency_key;

--- a/supabase/tests/fn_review_card.sql
+++ b/supabase/tests/fn_review_card.sql
@@ -1,0 +1,150 @@
+-- pgTAP test for fn_review_card (PR #48). Corroborating, NOT load-bearing
+-- per the new CLAUDE.md §"Rebutting council findings" rule (#7 makes
+-- db-tests `continue-on-error`). The consistently-passing failure-mode
+-- proofs live in apps/web/app/review/actions.test.ts.
+--
+-- This file documents the function's contract at the database level so
+-- that when #7 is fixed, the suite is ready to load-bear.
+
+begin;
+select plan(8);
+
+-- ===== Fixtures =========================================================
+
+insert into auth.users (id, instance_id, aud, role, email, encrypted_password, created_at, updated_at)
+values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'alice-fsrs@test.local', '', now(), now()),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'bob-fsrs@test.local', '', now(), now())
+on conflict (id) do nothing;
+
+insert into public.cohorts (id, name) values
+  ('11111111-1111-1111-1111-1111111111f1', 'Cohort FSRS')
+on conflict (id) do nothing;
+
+insert into public.cohort_members (cohort_id, user_id, role) values
+  ('11111111-1111-1111-1111-1111111111f1', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1', 'member'),
+  ('11111111-1111-1111-1111-1111111111f1', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1', 'member')
+on conflict do nothing;
+
+-- One note shared between the two users (per-cohort), one card owned by Alice.
+insert into public.notes (id, cohort_id, slug, title, body_md, tier)
+values ('cccccccc-cccc-cccc-cccc-cccccccccc01', '11111111-1111-1111-1111-1111111111f1', 'fsrs-test-note', 'Note', '...', 'active')
+on conflict (id) do nothing;
+
+insert into public.srs_cards (id, note_id, question, answer, fsrs_state, user_id, cohort_id)
+values ('dddddddd-dddd-dddd-dddd-dddddddddd01', 'cccccccc-cccc-cccc-cccc-cccccccccc01', 'q', 'a', '{}'::jsonb, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1', '11111111-1111-1111-1111-1111111111f1')
+on conflict (id) do nothing;
+
+-- ===== Test 1: function exists with the expected signature ==============
+select has_function(
+  'public', 'fn_review_card',
+  array['uuid','smallint','jsonb','timestamptz','jsonb','text'],
+  'fn_review_card exists with the (card_id, rating, next_state, due_at, prev_state, idempotency_key) signature'
+);
+
+-- ===== Test 2: function uses security invoker (NOT definer) =============
+select is(
+  (select prosecdef from pg_proc where proname = 'fn_review_card' limit 1),
+  false,
+  'fn_review_card uses security invoker (auth.uid() flows through to RLS)'
+);
+
+-- ===== Test 3: invalid rating raises 22023 ==============================
+prepare invalid_rating as
+  select fn_review_card(
+    'dddddddd-dddd-dddd-dddd-dddddddddd01'::uuid,
+    99::smallint,
+    '{"due":"2026-04-25T00:00:00Z","stability":1,"difficulty":1,"elapsed_days":0,"scheduled_days":0,"reps":1,"lapses":0,"state":1}'::jsonb,
+    now(),
+    '{}'::jsonb,
+    'idempotency-key-1'
+  );
+select throws_ok(
+  'invalid_rating',
+  '22023',
+  'invalid rating: 99',
+  'rating outside 1..4 raises invalid_parameter_value'
+);
+
+-- ===== Test 4: idempotency replay is a no-op success =====================
+-- Set the JWT claim so RLS allows the operation as Alice.
+set local request.jwt.claims = '{"sub":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1","role":"authenticated"}';
+
+select fn_review_card(
+  'dddddddd-dddd-dddd-dddd-dddddddddd01'::uuid,
+  3::smallint,
+  '{"due":"2026-04-25T00:00:00Z","stability":1,"difficulty":1,"elapsed_days":0,"scheduled_days":0,"reps":1,"lapses":0,"state":1}'::jsonb,
+  '2026-04-25T00:00:00Z'::timestamptz,
+  '{}'::jsonb,
+  'idempotency-key-2'
+);
+
+-- Snapshot rows for replay comparison.
+select is(
+  (select count(*)::int from public.review_history where idempotency_key = 'idempotency-key-2'),
+  1,
+  'first call inserts one review_history row'
+);
+
+-- Replay with same idempotency_key.
+select fn_review_card(
+  'dddddddd-dddd-dddd-dddd-dddddddddd01'::uuid,
+  3::smallint,
+  '{"due":"2026-04-25T00:00:00Z","stability":2,"difficulty":2,"elapsed_days":1,"scheduled_days":1,"reps":2,"lapses":0,"state":2}'::jsonb,
+  '2026-04-26T00:00:00Z'::timestamptz,
+  '{"due":"2026-04-25T00:00:00Z","stability":1,"difficulty":1,"elapsed_days":0,"scheduled_days":0,"reps":1,"lapses":0,"state":1}'::jsonb,
+  'idempotency-key-2'
+);
+
+select is(
+  (select count(*)::int from public.review_history where idempotency_key = 'idempotency-key-2'),
+  1,
+  'replay with same idempotency_key does NOT insert a duplicate row'
+);
+
+-- The card's fsrs_state must be unchanged from the first call (not the
+-- second's "different prev_state" attempt — replay shorts before the UPDATE).
+select is(
+  (select (fsrs_state->>'reps')::int from public.srs_cards where id = 'dddddddd-dddd-dddd-dddd-dddddddddd01'),
+  1,
+  'replay does NOT advance srs_cards.fsrs_state'
+);
+
+-- ===== Test 5: optimistic concurrency raises 40001 on stale prev_state ==
+prepare stale_prev as
+  select fn_review_card(
+    'dddddddd-dddd-dddd-dddd-dddddddddd01'::uuid,
+    3::smallint,
+    '{"due":"2026-04-27T00:00:00Z","stability":3,"difficulty":3,"elapsed_days":0,"scheduled_days":0,"reps":99,"lapses":0,"state":2}'::jsonb,
+    '2026-04-27T00:00:00Z'::timestamptz,
+    '{"stale":"prev"}'::jsonb,  -- does NOT match the card's current fsrs_state
+    'idempotency-key-3'
+  );
+select throws_ok(
+  'stale_prev',
+  '40001',
+  'concurrent update on card dddddddd-dddd-dddd-dddd-dddddddddd01',
+  'mismatched p_prev_state raises serialization_failure (40001)'
+);
+
+-- ===== Test 6: cross-user RLS — Bob cannot review Alice's card ==========
+set local request.jwt.claims = '{"sub":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1","role":"authenticated"}';
+
+prepare cross_user as
+  select fn_review_card(
+    'dddddddd-dddd-dddd-dddd-dddddddddd01'::uuid,
+    3::smallint,
+    '{}'::jsonb,
+    now(),
+    '{}'::jsonb,
+    'idempotency-key-4'
+  );
+select throws_ok(
+  'cross_user',
+  '42501',
+  'card not found or not accessible: dddddddd-dddd-dddd-dddd-dddddddddd01',
+  'Bob cannot review Alice''s card — RLS blocks the select, function raises 42501'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Plan-first PR for FSRS rating on \`/review\` — closes the SRS loop opened by issue #38 (PR #42 shipped read-only review; this PR adds rating + state advancement). Triggers council via \`.github/workflows/council.yml\`. **No code in this PR** — implementation lands as follow-up commits on the same branch after the human approves the council synthesis.

Per the new PR-title-hygiene reminder (issue #46), title is set to \`feat(srs):\` from the start so the eventual squash-merge inherits the right category.

## What this plan proposes

- 4 rating buttons (Again/Hard/Good/Easy) on \`/review\`, enabled after answer reveal.
- Server action \`submitReview(cardId, rating)\` running the FSRS algorithm.
- Single SQL function \`fn_review_card\` (\`security invoker\`) atomically updating \`srs_cards.fsrs_state\` + \`due_at\` AND inserting \`review_history\`.
- New runtime dep: \`ts-fsrs\` (canonical TS port of FSRS-5), wrapped in \`packages/lib/srs/\`.
- 6 new i18n keys; no new RLS policies (both touched tables already per-user).

## Files in this PR

- \`.harness/active_plan.md\` — full plan.

## Council axes anticipated

- **Security:** \`security invoker\` choice; RLS coverage on the new RPC; PII-safe error logging; rating validation before DB call.
- **Bugs:** atomicity boundary; \`fsrs_state = {}\` new-card branch; double-click guard; concurrent-rating race.
- **Architecture:** wrapper-package pattern for \`ts-fsrs\`; SQL-function-as-transaction-boundary.
- **Cost:** zero runtime; new-runtime-dep council scrutiny on \`ts-fsrs\` vs minimal in-house impl.
- **Product:** FSRS rating set; closes the loop.
- **a11y:** \`role="group"\` on rating cluster; \`disabled\` during pending; focus-management on auto-advance.

## Plan respects new CLAUDE.md rules from PR #43

- §"Plan-time required content": isolation model named + justified for both touched tables (per-user, already shipped).
- §"Rebutting council findings": test plan includes failure-mode coverage for every surface (algorithm ordering invariant, PII negative-sentinel, RLS-blocked card path).
- PR-title hygiene (#46): \`feat(srs):\` set from PR creation.

## Test plan

- [ ] Council workflow runs and posts \`<!-- council-report -->\` synthesis.
- [ ] Human reviews synthesis, approves (or requests revisions).
- [ ] On approval: implementation commits land on this same branch.
- [ ] \`npm run lint\`, \`npm run typecheck\`, \`npm test\` pass on impl-diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)